### PR TITLE
[ART-3090] Fix manifests for ART builds

### DIFF
--- a/bundle/4.9/manifests/image-references
+++ b/bundle/4.9/manifests/image-references
@@ -2,7 +2,7 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  - name: special-resource-operator
+  - name: special-resource-rhel8-operator
     from:
       kind: DockerImage
       name: quay.io/openshift/special-resource-rhel8-operator:4.9

--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -7,7 +7,7 @@ updates:
       replace: "version: {FULL_VER}"
     - search: 'olm.skipRange: ">=4.6.0 <{MAJOR}.{MINOR}.0"'
       replace: 'olm.skipRange: ">=4.6.0 <{FULL_VER}"'
-  - file: "nfd.package.yaml"
+  - file: "special-resource-operator.package.yaml"
     update_list:
     - search: "currentCSV: special-resource-operator.v{MAJOR}.{MINOR}.0"
       replace: "currentCSV: special-resource-operator.{FULL_VER}"


### PR DESCRIPTION
Couple errors I caught while trying to test building it through ART.
With those changes applied, we managed to get the following successful builds in brew:
* operator: [special-resource-operator-container-v4.9.0-202107161313.p0.git.d0562b4.assembly.stream](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1665437)
* bundle: [special-resource-operator-bundle-container-v4.9.0.202107161313.p0.git.d0562b4.assembly.stream-1](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=1665457)