### PR TITLE
Bug 1987136: Declare supported arches in CSV

### DIFF
--- a/config/manifests/bases/special-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/special-resource-operator.clusterserviceversion.yaml
@@ -8,6 +8,8 @@ metadata:
     description: The special resource operator is an orchestrator for resources in a cluster required to deploy special hardware and software. Examples include hardware accelerators or software defined storage, where extra management or kernel modules are needed.
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: special-resource-operator.vX.Y.Z
   namespace: placeholder
 spec:


### PR DESCRIPTION
The OperatorHub currently assumes x86-only for any operators which do
not declare any such labels.  Declaring these explicitly should make the
current status more obvious in the code, and make it easier to correctly
add further architectures when conditions warrant.
