### PR TITLE
Bug 2000226: Unable to have multiple charts in one configmap

### DIFF
--- a/.patches/getter.patch.go
+++ b/.patches/getter.patch.go
@@ -91,8 +91,10 @@ func (g *ConfigMapGetter) Get(href string, option ...Option) (*bytes.Buffer, err
 		return bytes.NewBuffer([]byte(asciiData["index.yaml"])), nil
 	}
 
-	for _, v := range binaryData {
-		return bytes.NewBuffer(v), nil
+	for k, v := range binaryData {
+		if s[2] == k {
+			return bytes.NewBuffer(v), nil
+		}
 	}
 
 	return nil, errors.New(fmt.Sprintf("Cannot find any asciiData | binaryData in CM %+v\n", chart))

--- a/OWNERS
+++ b/OWNERS
@@ -8,4 +8,5 @@ reviewers:
   - ArangoGutierrez
   - dagrayvid
   - kpouget
+  - pacevedom
 component: "Special Resource Operator"

--- a/bundle/4.9/manifests/special-resource-operator.v4.9.0.clusterserviceversion.yaml
+++ b/bundle/4.9/manifests/special-resource-operator.v4.9.0.clusterserviceversion.yaml
@@ -48,7 +48,7 @@ metadata:
     capabilities: Basic Install
     categories: AI/Machine Learning, Drivers and plugins, Networking, Storage
     description: The special resource operator is an orchestrator for resources in a cluster required to deploy special hardware and software. Examples include hardware accelerators or software defined storage, where extra management or kernel modules are needed.
-    olm.skipRange: ">=4.6.0 <4.9.0"
+    olm.skipRange: '>=4.6.0 <4.9.0'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   labels:

--- a/charts/infoscale/infoscale-vtas-0.0.1/templates/3000-driver-container.yaml
+++ b/charts/infoscale/infoscale-vtas-0.0.1/templates/3000-driver-container.yaml
@@ -177,6 +177,8 @@ spec:
           mountPath: /opt/VRTS/install/logs
         - name: log-tmpinstall
           mountPath: /opt/VRTStmp
+        - name: date-config
+          mountPath: /etc/localtime
       terminationGracePeriodSeconds: {{.Values.runArgs.terminationPeriod}}
       restartPolicy: Always
       tolerations:
@@ -201,6 +203,10 @@ spec:
               secretName: rest-tls-cert
 
 # Creating separate hostpath volume for each log destination
+        - name: date-config
+          hostPath:
+              path: /etc/localtime
+              type: FileOrCreate
         - name: log-sys
           hostPath:
               path: /var/VRTS/log/var/log

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,5 +6,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/openshift-psap/special-resource-operator
-  newTag: ondelete
+  newName: quay.io/openshift/special-resource-rhel8-operator
+  newTag: "4.9"

--- a/config/manifests/bases/special-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/special-resource-operator.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: AI/Machine Learning, Drivers and plugins, Networking, Storage
     description: The special resource operator is an orchestrator for resources in a cluster required to deploy special hardware and software. Examples include hardware accelerators or software defined storage, where extra management or kernel modules are needed.
+    olm.skipRange: '>=4.6.0 <4.9.0'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   labels:

--- a/test/e2e/basic/simple-kmod.go
+++ b/test/e2e/basic/simple-kmod.go
@@ -181,6 +181,10 @@ func simpleKmodDelete(cs *framework.ClientSet, cl client.Client) {
 	for _, node := range nodes {
 		//run command in pod
 		ginkgo.By("Ensuring that the simple-kmod is unloaded")
+		if !IsNodeReady(node) {
+			ginkgo.By(fmt.Sprintf("Skipping NotReady node %s", node.Name))
+			continue
+		}
 		// || true at the end of grep command because we don't want grep to exit with an error code if no matches are found.
 		unloadCmd := []string{"/bin/sh", "-c", "/host/usr/sbin/lsmod | grep -c simple-kmod || true"}
 		unloadValExp := "0"

--- a/test/e2e/basic/util.go
+++ b/test/e2e/basic/util.go
@@ -286,3 +286,17 @@ func WaitForClusterOperatorCondition(cs *framework.ClientSet, interval, duration
 	}
 	return nil
 }
+
+// IsNodeReady helps determine if a given node is ready or not.
+func IsNodeReady(node corev1.Node) bool {
+	found := false
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			found = true
+			if condition.Status != corev1.ConditionTrue {
+				return false
+			}
+		}
+	}
+	return found
+}

--- a/test/e2e/basic/util.go
+++ b/test/e2e/basic/util.go
@@ -289,14 +289,10 @@ func WaitForClusterOperatorCondition(cs *framework.ClientSet, interval, duration
 
 // IsNodeReady helps determine if a given node is ready or not.
 func IsNodeReady(node corev1.Node) bool {
-	found := false
 	for _, condition := range node.Status.Conditions {
 		if condition.Type == corev1.NodeReady {
-			found = true
-			if condition.Status != corev1.ConditionTrue {
-				return false
-			}
+			return condition.Status == corev1.ConditionTrue
 		}
 	}
-	return found
+	return false
 }

--- a/vendor/helm.sh/helm/v3/pkg/getter/getter.patch.go
+++ b/vendor/helm.sh/helm/v3/pkg/getter/getter.patch.go
@@ -91,8 +91,10 @@ func (g *ConfigMapGetter) Get(href string, option ...Option) (*bytes.Buffer, err
 		return bytes.NewBuffer([]byte(asciiData["index.yaml"])), nil
 	}
 
-	for _, v := range binaryData {
-		return bytes.NewBuffer(v), nil
+	for k, v := range binaryData {
+		if s[2] == k {
+			return bytes.NewBuffer(v), nil
+		}
 	}
 
 	return nil, errors.New(fmt.Sprintf("Cannot find any asciiData | binaryData in CM %+v\n", chart))


### PR DESCRIPTION
This PR syncs the downstream repo with upstream, most importantly to fix the referenced BZ.

The other minor changes from upstream:
- Make sure debug pods in e2e test are assigned to Ready nodes only.
- Add olm skiprange to the "master copy" of the CSV config/manifests/bases/special-resource-operator.clusterserviceversion.yaml so that future bundle updates will keep the change from #32 
- Add pacevedo to reviewers
- Add upstream fix to infoscale special resource.

/cc @SchSeba 