### PR TITLE
Bug 2009888: Rename project to openshift-special-resource-operator 

### DIFF
--- a/Makefile.helper.mk
+++ b/Makefile.helper.mk
@@ -65,7 +65,7 @@ endif
 update-bundle: 
 	rm -rf bundle/4.*/manifests bundle/4.*/metadata
 	$(MAKE) bundle DEFAULT_CHANNEL=$(DEFAULT_CHANNEL) VERSION=$(VERSION) IMAGE=$(IMAGE)
-	mv bundle/manifests/special-resource-operator.clusterserviceversion.yaml bundle/manifests/special-resource-operator.v$(VERSION).clusterserviceversion.yaml
+	mv bundle/manifests/openshift-special-resource-operator.clusterserviceversion.yaml bundle/manifests/openshift-special-resource-operator.v$(VERSION).clusterserviceversion.yaml
 	mv bundle/manifests bundle/$(DEFAULT_CHANNEL)/manifests
 	mv bundle/metadata bundle/$(DEFAULT_CHANNEL)/metadata
 	sed 's#bundle/##g' bundle.Dockerfile | head -n -1 > bundle/$(DEFAULT_CHANNEL)/bundle.Dockerfile

--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,6 @@
 domain: openshift.io
 layout: go.kubebuilder.io/v2
-projectName: special-resource-operator
+projectName: openshift-special-resource-operator
 repo: github.com/openshift-psap/special-resource-operator
 resources:
 - group: sro

--- a/bundle/4.9/bundle.Dockerfile
+++ b/bundle/4.9/bundle.Dockerfile
@@ -3,7 +3,7 @@ FROM scratch
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=special-resource-operator
+LABEL operators.operatorframework.io.bundle.package.v1=openshift-special-resource-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=4.9
 LABEL operators.operatorframework.io.bundle.channel.default.v1=4.9
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.2.0

--- a/bundle/4.9/manifests/openshift-special-resource-operator.v4.9.0.clusterserviceversion.yaml
+++ b/bundle/4.9/manifests/openshift-special-resource-operator.v4.9.0.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: special-resource-operator.v4.9.0
+  name: openshift-special-resource-operator.v4.9.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/bundle/4.9/metadata/annotations.yaml
+++ b/bundle/4.9/metadata/annotations.yaml
@@ -4,7 +4,7 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: special-resource-operator
+  operators.operatorframework.io.bundle.package.v1: openshift-special-resource-operator
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.2.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2

--- a/config/manifests/bases/openshift-special-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-special-resource-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: special-resource-operator.vX.Y.Z
+  name: openshift-special-resource-operator.vX.Y.Z
   namespace: placeholder
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
The SRO CSV name collides with the community operator name.  Because it's easier to rename the one that is not yet publicly available, we can fix this by renaming the downstream CSV (and project) to openshift-special-resource-operator. See BZ and discussion in the ART slack channel for why this is needed.

This will mean that going forward the upstream and downstream bundle will diverge. The upstream bundle can become the community version, and downstream can be the ART version. When we cherry-pick changes from upstream, we will need to regenerate the downstream bundle.

/cc @bthurber @pacevedom @thiagoalessio 