### PR TITLE
Bug 2010911: RenderOperatingSystem() returns wrong OS version on OCP 4.7.24

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -139,7 +139,7 @@ func OperatingSystem() (string, string, string, error) {
 	if rhelVersion, found := labels[os+".RHEL_VERSION"]; found && len(rhelVersion) == 3 {
 		rhelMaj := rhelVersion[0:1]
 		rhelMin := rhelVersion[2:]
-		return "rhel" + rhelVersion, "rhel" + rhelMaj, rhelMaj + "." + rhelMin, nil
+		return "rhel" + rhelMaj, "rhel" + rhelVersion, rhelMaj + "." + rhelMin, nil
 	}
 
 	// On vanilla k8s and older NFD versions, we need RenderOperatingSystem

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -112,17 +112,21 @@ func OSImageURL() (string, error) {
 	return osImageURL, nil
 }
 
+// Assumes all nodes have the same OS.
+// Returns the os in the following forms:
+// rhelx.y, rhelx, x.y
 func OperatingSystem() (string, string, string, error) {
 
 	var nodeOSrel string
 	var nodeOSmaj string
 	var nodeOSmin string
+	var labels map[string]string
 
 	// Assuming all nodes are running the same os
 	os := "feature.node.kubernetes.io/system-os_release"
 
 	for _, node := range cache.Node.List.Items {
-		labels := node.GetLabels()
+		labels = node.GetLabels()
 		nodeOSrel = labels[os+".ID"]
 		nodeOSmaj = labels[os+".VERSION_ID.major"]
 		nodeOSmin = labels[os+".VERSION_ID.minor"]
@@ -131,7 +135,14 @@ func OperatingSystem() (string, string, string, error) {
 			return "", "", "", errors.New("Cannot extract " + os + ".*, is NFD running? Check node labels")
 		}
 	}
+	// On OCP >4.7, we can use the NFD label  feature.node.kubernetes.io/system-os_release.RHEL_VERSION label.
+	if rhelVersion, found := labels[os+".RHEL_VERSION"]; found && len(rhelVersion) == 3 {
+		rhelMaj := rhelVersion[0:1]
+		rhelMin := rhelVersion[2:]
+		return "rhel" + rhelVersion, "rhel" + rhelMaj, rhelMaj + "." + rhelMin, nil
+	}
 
+	// On vanilla k8s and older NFD versions, we need RenderOperatingSystem
 	return osversion.RenderOperatingSystem(nodeOSrel, nodeOSmaj, nodeOSmin)
 }
 

--- a/pkg/osversion/osversion.go
+++ b/pkg/osversion/osversion.go
@@ -18,7 +18,7 @@ func RenderOperatingSystem(rel string, maj string, min string) (string, string, 
 		case min <= "6":
 			rhelMin = "2"
 		case min <= "7":
-			rhelMin = "3"
+			rhelMin = "4"
 		case min <= "8":
 			rhelMin = "4"
 		}


### PR DESCRIPTION
Fix RHEL version resolution under OCP 4.7.24+, where RHEL version changed from 8.3 to 8.4 and this was mistakenly fixed to 8.3 for all OCP 4.7.z versions.