### PR TITLE
Bug 2011977: Use origin image in bundle

### DIFF
--- a/bundle/4.9/manifests/openshift-special-resource-operator.v4.9.0.clusterserviceversion.yaml
+++ b/bundle/4.9/manifests/openshift-special-resource-operator.v4.9.0.clusterserviceversion.yaml
@@ -1293,7 +1293,7 @@ spec:
                   value: 0.0.1-snapshot
                 - name: SSL_CERT_DIR
                   value: /etc/pki/tls/certs
-                image: quay.io/openshift/special-resource-rhel8-operator:4.9
+                image: quay.io/openshift/origin-special-resource-rhel8-operator:4.9
                 imagePullPolicy: Always
                 name: manager
                 resources:

--- a/bundle/image-references
+++ b/bundle/image-references
@@ -5,7 +5,7 @@ spec:
   - name: special-resource-rhel8-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/special-resource-rhel8-operator:4.9
+      name: quay.io/openshift/origin-special-resource-rhel8-operator:4.9
   - name: kube-rbac-proxy
     from:
       kind: DockerImage

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,5 +6,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/openshift/special-resource-rhel8-operator
+  newName: quay.io/openshift/origin-special-resource-rhel8-operator
   newTag: "4.9"


### PR DESCRIPTION
Currently we are unable to run the operator bundle in the openshift/special-resource-operator repository, because it uses a nonexistent image quay.io/openshift/special-resource-rhel8-operator:4.9.   To be consistent with other optional operators we should be using the origin image quay.io/openshift/origin-special-resource-rhel8-operator:4.9.

/cc @pacevedom 
/cc @SchSeba 
