### PR TITLE
Fixing README to point to the d/s repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Special Resource Operator is available as a community operator on OperatorHu
 
 ## From the CLI
 ```
-$ git clone https://github.com/openshift-psap/special-resource-operator
+$ git clone https://github.com/openshift/special-resource-operator
 $ cd special-resource-operator
 $ TAG=master make deploy
 ```


### PR DESCRIPTION
It make no sense that the d/s README point to the u/s repo.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>