### PR TITLE
Bug 2034766: Special Resource Operator(SRO) - no cert-manager pod created in dual stack environment

### DIFF
--- a/controllers/runtime.go
+++ b/controllers/runtime.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift-psap/special-resource-operator/pkg/kernel"
 	"github.com/openshift-psap/special-resource-operator/pkg/proxy"
 	"github.com/openshift-psap/special-resource-operator/pkg/upgrade"
+	"github.com/openshift-psap/special-resource-operator/pkg/warn"
 	"github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -126,9 +127,7 @@ func getRuntimeInformation(r *SpecialResourceReconciler) error {
 	}
 
 	RunInfo.PushSecretName, err = retryGetPushSecretName(r)
-	if err != nil {
-		return fmt.Errorf("failed to get push secret name: %w", err)
-	}
+	warn.OnError(err)
 
 	RunInfo.OSImageURL, err = cluster.OSImageURL()
 	if err != nil {


### PR DESCRIPTION
Failure to retrieve the pull secret should not return an early error, as it is only found after creating the namespace and this operation has not been done yet.