### PR TITLE
Bug 2030840: set an initial ClusterOperator status

### DIFF
--- a/pkg/utils/conditions.go
+++ b/pkg/utils/conditions.go
@@ -35,6 +35,36 @@ func AvailableNotProgressingNotDegraded() []configv1.ClusterOperatorStatusCondit
 	}
 }
 
+func EndConditions(err error) []configv1.ClusterOperatorStatusCondition {
+	now := metav1.Now()
+
+	conds := []configv1.ClusterOperatorStatusCondition{
+		{
+			Type:               configv1.OperatorAvailable,
+			Status:             configv1.ConditionFalse,
+			LastTransitionTime: metav1.Now(),
+		},
+		{
+			Type:               configv1.OperatorProgressing,
+			Status:             configv1.ConditionFalse,
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+
+	degraded := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorDegraded,
+		Status:             configv1.ConditionFalse,
+		LastTransitionTime: now,
+	}
+
+	if err != nil {
+		degraded.Status = configv1.ConditionTrue
+		degraded.Message = err.Error()
+	}
+
+	return append(conds, degraded)
+}
+
 // NotAvailableProgressingNotDegraded NotAvailableProgressingNotDegraded
 func NotAvailableProgressingNotDegraded(
 	msgAvailable string,

--- a/pkg/utils/conditions_test.go
+++ b/pkg/utils/conditions_test.go
@@ -1,6 +1,10 @@
 package utils
 
 import (
+	"errors"
+	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
@@ -14,6 +18,10 @@ type conditionTemplate struct {
 	message  string
 }
 
+func (ct conditionTemplate) String() string {
+	return fmt.Sprintf("%s=%s", ct.condType, ct.status)
+}
+
 func findAndCompareCondition(conditions []configv1.ClusterOperatorStatusCondition, expected conditionTemplate) {
 	cond := v1helpers.FindStatusCondition(conditions, expected.condType)
 
@@ -21,89 +29,118 @@ func findAndCompareCondition(conditions []configv1.ClusterOperatorStatusConditio
 	Expect(cond.Status).To(Equal(expected.status))
 	Expect(cond.Reason).To(Equal(expected.reason))
 	Expect(cond.Message).To(Equal(expected.message))
-	Expect(cond.LastTransitionTime).NotTo(BeZero())
+	Expect(cond.LastTransitionTime.Time).To(BeTemporally("~", time.Now(), time.Second))
 }
 
-func descFromConditionTemplate(ct conditionTemplate) string {
-	return string(ct.condType)
-}
+var _ = Describe("AvailableNotProgressingNotDegraded", func() {
+	templates := []conditionTemplate{
+		{
+			condType: configv1.OperatorAvailable,
+			status:   configv1.ConditionTrue,
+			reason:   "AsExpected",
+			message:  "Reconciled all SpecialResources",
+		},
+		{
+			condType: configv1.OperatorProgressing,
+			status:   configv1.ConditionFalse,
+			reason:   "Reconciled",
+			message:  "SpecialResources up to date",
+		},
+		{
+			condType: configv1.OperatorDegraded,
+			status:   configv1.ConditionFalse,
+			reason:   "AsExpected",
+			message:  "Special Resource Operator reconciling special resources",
+		},
+	}
 
-var _ = Describe("Conditions", func() {
-	Context("AvailableNotProgressingNotDegraded", func() {
-		templates := []conditionTemplate{
-			{
-				condType: configv1.OperatorAvailable,
-				status:   configv1.ConditionTrue,
-				reason:   "AsExpected",
-				message:  "Reconciled all SpecialResources",
-			},
-			{
-				condType: configv1.OperatorProgressing,
-				status:   configv1.ConditionFalse,
-				reason:   "Reconciled",
-				message:  "SpecialResources up to date",
-			},
-			{
-				condType: configv1.OperatorDegraded,
-				status:   configv1.ConditionFalse,
-				reason:   "AsExpected",
-				message:  "Special Resource Operator reconciling special resources",
-			},
-		}
+	conds := AvailableNotProgressingNotDegraded()
 
-		conds := AvailableNotProgressingNotDegraded()
+	DescribeTable(
+		"all conditions",
+		func(ct conditionTemplate) {
+			findAndCompareCondition(conds, ct)
+		},
+		Entry(nil, templates[0]),
+		Entry(nil, templates[1]),
+		Entry(nil, templates[2]),
+	)
+})
 
-		DescribeTable(
-			"all conditions",
-			func(ct conditionTemplate) {
-				findAndCompareCondition(conds, ct)
-			},
-			descFromConditionTemplate,
-			Entry(nil, templates[0]),
-			Entry(nil, templates[1]),
-			Entry(nil, templates[2]),
-		)
-	})
+var _ = Describe("EndConditions", func() {
+	const errMsg = "random error"
 
-	Context("NotAvailableProgressingNotDegraded", func() {
-		const (
-			msgAvailable   = "some-msg-available"
-			msgProgressing = "some-msg-progressing"
-			msgDegraded    = "some-msg-degraded"
-		)
+	randomError := errors.New(errMsg)
 
-		conds := NotAvailableProgressingNotDegraded(msgAvailable, msgProgressing, msgDegraded)
+	templates := []conditionTemplate{
+		{
+			condType: configv1.OperatorAvailable,
+			status:   configv1.ConditionFalse,
+		},
+		{
+			condType: configv1.OperatorProgressing,
+			status:   configv1.ConditionFalse,
+		},
+		{
+			condType: configv1.OperatorDegraded,
+			status:   configv1.ConditionFalse,
+		},
+		{
+			condType: configv1.OperatorDegraded,
+			status:   configv1.ConditionTrue,
+			message:  errMsg,
+		},
+	}
 
-		templates := []conditionTemplate{
-			{
-				condType: configv1.OperatorAvailable,
-				status:   configv1.ConditionFalse,
-				reason:   "Reconciling",
-				message:  msgAvailable,
-			},
-			{
-				condType: configv1.OperatorProgressing,
-				status:   configv1.ConditionTrue,
-				reason:   "Reconciling",
-				message:  msgProgressing,
-			},
-			{
-				condType: configv1.OperatorDegraded,
-				status:   configv1.ConditionFalse,
-				reason:   "Reconciled",
-				message:  msgDegraded,
-			},
-		}
+	DescribeTable(
+		"all conditions",
+		func(ct conditionTemplate, err error) {
+			findAndCompareCondition(EndConditions(err), ct)
+		},
+		Entry(nil, templates[0], nil),
+		Entry(nil, templates[1], nil),
+		Entry(nil, templates[2], nil),
+		Entry(nil, templates[3], randomError),
+	)
+})
 
-		DescribeTable(
-			"all conditions",
-			func(ct conditionTemplate) {
-				findAndCompareCondition(conds, ct)
-			},
-			descFromConditionTemplate,
-			Entry(nil, templates[0]),
-			Entry(nil, templates[1]),
-			Entry(nil, templates[2]),
-		)
-	})
+var _ = Describe("NotAvailableProgressingNotDegraded", func() {
+	const (
+		msgAvailable   = "some-msg-available"
+		msgProgressing = "some-msg-progressing"
+		msgDegraded    = "some-msg-degraded"
+	)
+
+	conds := NotAvailableProgressingNotDegraded(msgAvailable, msgProgressing, msgDegraded)
+
+	templates := []conditionTemplate{
+		{
+			condType: configv1.OperatorAvailable,
+			status:   configv1.ConditionFalse,
+			reason:   "Reconciling",
+			message:  msgAvailable,
+		},
+		{
+			condType: configv1.OperatorProgressing,
+			status:   configv1.ConditionTrue,
+			reason:   "Reconciling",
+			message:  msgProgressing,
+		},
+		{
+			condType: configv1.OperatorDegraded,
+			status:   configv1.ConditionFalse,
+			reason:   "Reconciled",
+			message:  msgDegraded,
+		},
+	}
+
+	DescribeTable(
+		"all conditions",
+		func(ct conditionTemplate) {
+			findAndCompareCondition(conds, ct)
+		},
+		Entry(nil, templates[0]),
+		Entry(nil, templates[1]),
+		Entry(nil, templates[2]),
+	)
 })


### PR DESCRIPTION
This PR makes the application set an initial `ClusterOperator` status as soon as it starts.
It also uses `defer` to make sure that the status is updated when it exits.

Per the BZ, the `ClusterOperator`'s name is also prefixed with `openshift-`.

This PR requires #95 to be merged. Then the first commit (d6402d28941e49f0f3f209a9b50c98794dbe535b) should be deleted from this PR.

/hold