### PR TITLE
Use DTK ImageStream to get an DTK image URL

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -52,7 +52,7 @@ func (c *cluster) GetDTKImages(ctx context.Context) ([]string, error) {
 		types.NamespacedName{Namespace: "openshift", Name: "driver-toolkit"},
 		&is)
 	if err != nil {
-		return []string{}, fmt.Errorf("could not obtain openshift/driver-toolkit ImageStream: %w", err)
+		return nil, fmt.Errorf("could not obtain openshift/driver-toolkit ImageStream: %w", err)
 	}
 
 	type tagRef struct {
@@ -73,7 +73,7 @@ func (c *cluster) GetDTKImages(ctx context.Context) ([]string, error) {
 		return trs[i].created.After(trs[j].created)
 	})
 
-	refs := []string{}
+	refs := make([]string, 0, len(trs))
 	for _, tr := range trs {
 		refs = append(refs, tr.ref)
 	}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -275,10 +275,12 @@ var _ = Describe("cluster_GetDTKImages", func() {
 	})
 
 	It("should return sorted slice of URLs", func() {
-		remoteRegistryURL := "reg.io/release/repo"
-		img1 := "sha256:1"
-		img2 := "sha256:2"
-		img3 := "sha256:3"
+		const (
+			remoteRegistryURL = "reg.io/release/repo"
+			img1              = "sha256:1"
+			img2              = "sha256:2"
+			img3              = "sha256:3"
+		)
 
 		mockKubeClients.EXPECT().
 			Get(gomock.Any(), types.NamespacedName{Namespace: "openshift", Name: "driver-toolkit"}, gomock.Any()).

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -269,9 +269,8 @@ var _ = Describe("cluster_GetDTKImages", func() {
 			Get(gomock.Any(), types.NamespacedName{Namespace: "openshift", Name: "driver-toolkit"}, gomock.Any()).
 			Return(randomError)
 
-		urls, err := cluster.NewCluster(mockKubeClients).GetDTKImages(context.TODO())
+		_, err := cluster.NewCluster(mockKubeClients).GetDTKImages(context.TODO())
 		Expect(err).To(HaveOccurred())
-		Expect(urls).To(HaveLen(0))
 	})
 
 	It("should return sorted slice of URLs", func() {

--- a/pkg/cluster/mock_cluster_api.go
+++ b/pkg/cluster/mock_cluster_api.go
@@ -35,6 +35,21 @@ func (m *MockCluster) EXPECT() *MockClusterMockRecorder {
 	return m.recorder
 }
 
+// GetDTKImages mocks base method.
+func (m *MockCluster) GetDTKImages(arg0 context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDTKImages", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDTKImages indicates an expected call of GetDTKImages.
+func (mr *MockClusterMockRecorder) GetDTKImages(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDTKImages", reflect.TypeOf((*MockCluster)(nil).GetDTKImages), arg0)
+}
+
 // OSImageURL mocks base method.
 func (m *MockCluster) OSImageURL(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
@@ -81,19 +96,4 @@ func (m *MockCluster) Version(arg0 context.Context) (string, string, error) {
 func (mr *MockClusterMockRecorder) Version(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockCluster)(nil).Version), arg0)
-}
-
-// VersionHistory mocks base method.
-func (m *MockCluster) VersionHistory(arg0 context.Context) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VersionHistory", arg0)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// VersionHistory indicates an expected call of VersionHistory.
-func (mr *MockClusterMockRecorder) VersionHistory(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VersionHistory", reflect.TypeOf((*MockCluster)(nil).VersionHistory), arg0)
 }

--- a/pkg/registry/mock_registry_api.go
+++ b/pkg/registry/mock_registry_api.go
@@ -36,10 +36,10 @@ func (m *MockRegistry) EXPECT() *MockRegistryMockRecorder {
 }
 
 // ExtractToolkitRelease mocks base method.
-func (m *MockRegistry) ExtractToolkitRelease(arg0 v1.Layer) (DriverToolkitEntry, error) {
+func (m *MockRegistry) ExtractToolkitRelease(arg0 v1.Layer) (*DriverToolkitEntry, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExtractToolkitRelease", arg0)
-	ret0, _ := ret[0].(DriverToolkitEntry)
+	ret0, _ := ret[0].(*DriverToolkitEntry)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -44,7 +44,7 @@ type DriverToolkitEntry struct {
 
 type Registry interface {
 	LastLayer(context.Context, string) (v1.Layer, error)
-	ExtractToolkitRelease(v1.Layer) (DriverToolkitEntry, error)
+	ExtractToolkitRelease(v1.Layer) (*DriverToolkitEntry, error)
 	ReleaseManifests(v1.Layer) (string, string, error)
 }
 
@@ -154,8 +154,8 @@ func (r *registry) LastLayer(ctx context.Context, entry string) (v1.Layer, error
 	return crane.PullLayer(repo+"@"+digest, registryAuths...)
 }
 
-func (r *registry) ExtractToolkitRelease(layer v1.Layer) (DriverToolkitEntry, error) {
-	var dtk DriverToolkitEntry
+func (r *registry) ExtractToolkitRelease(layer v1.Layer) (*DriverToolkitEntry, error) {
+	dtk := &DriverToolkitEntry{}
 
 	targz, err := layer.Compressed()
 	if err != nil {

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -67,7 +67,7 @@ func (ci *clusterInfo) GetClusterInfo(ctx context.Context, nodeList *corev1.Node
 
 	dtkImages, err := ci.cluster.GetDTKImages(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("could not get version history: %w", err)
+		return nil, fmt.Errorf("could not get DTK images: %w", err)
 	}
 
 	versions, err := ci.driverToolkitVersion(ctx, dtkImages, info)

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -180,8 +180,7 @@ func (ci *clusterInfo) driverToolkitVersion(ctx context.Context, dtkImages []str
 	var dtk *registry.DriverToolkitEntry
 	imageURL := dtkImages[0]
 
-	if cached := ci.cache[imageURL]; cached != nil {
-		dtk = cached
+	if dtk = ci.cache[imageURL]; dtk != nil {
 		ci.log.Info("History from cache", "imageURL", imageURL, "dtk", dtk)
 	} else {
 		layer, err := ci.registry.LastLayer(ctx, imageURL)

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -73,7 +73,7 @@ var _ = Describe("ClusterInfo", func() {
 		nodesLabels    []map[string]string
 		clusterVersion string
 		dtkImages      []string
-		dtk            registry.DriverToolkitEntry
+		dtk            *registry.DriverToolkitEntry
 	}
 
 	kernel := "4.18.0-305.19.1.el8_4.x86_64"
@@ -95,7 +95,7 @@ var _ = Describe("ClusterInfo", func() {
 		labelOSReleaseVersionID:   clusterVersion,
 		labelOSReleaseRHELVersion: fmt.Sprintf("%s.%s", systemMajor, systemMinor),
 	}
-	clusterDTK := registry.DriverToolkitEntry{
+	clusterDTK := &registry.DriverToolkitEntry{
 		ImageURL:            "",
 		KernelFullVersion:   kernel,
 		RTKernelFullVersion: kernelRT,

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -70,11 +70,10 @@ var _ = Describe("ClusterInfo", func() {
 	})
 
 	type testInput struct {
-		nodesLabels          []map[string]string
-		clusterVersion       string
-		clusterReleaseImages []string
-		dtkImage             string
-		dtk                  registry.DriverToolkitEntry
+		nodesLabels    []map[string]string
+		clusterVersion string
+		dtkImages      []string
+		dtk            registry.DriverToolkitEntry
 	}
 
 	kernel := "4.18.0-305.19.1.el8_4.x86_64"
@@ -84,8 +83,7 @@ var _ = Describe("ClusterInfo", func() {
 	systemMinor := "4"
 	clusterVersion := "4.9"
 
-	clusterReleaseImages := []string{"quay.io/release/release@sha256:1234567890abcdef"}
-	dtkImageURL := "quay.io/dtk-image/dtk@sha256:1234567890abcdef"
+	dtkImages := []string{"quay.io/dtk-image/dtk@sha256:1234567890abcdef"}
 
 	nodeLabelsWithRTKernel := map[string]string{
 		labelKernelVersionFull:    kernelRT,
@@ -114,10 +112,8 @@ var _ = Describe("ClusterInfo", func() {
 
 			ctx := context.TODO()
 
-			mockCluster.EXPECT().VersionHistory(ctx).Return(input.clusterReleaseImages, nil)
-			mockRegistry.EXPECT().LastLayer(ctx, input.clusterReleaseImages[0]).Return(&fakeLayer{}, nil)
-			mockRegistry.EXPECT().ReleaseManifests(gomock.Any()).Return(input.clusterVersion, input.dtkImage, nil)
-			mockRegistry.EXPECT().LastLayer(ctx, input.dtkImage).Return(&fakeLayer{}, nil)
+			mockCluster.EXPECT().GetDTKImages(ctx).Return(input.dtkImages, nil)
+			mockRegistry.EXPECT().LastLayer(ctx, input.dtkImages[0]).Return(&fakeLayer{}, nil)
 			mockRegistry.EXPECT().ExtractToolkitRelease(gomock.Any()).Return(input.dtk, nil)
 
 			m, err := clusterInfo.GetClusterInfo(ctx, &nodesList)
@@ -131,11 +127,10 @@ var _ = Describe("ClusterInfo", func() {
 			Entry(
 				"1 node with RT kernel",
 				testInput{
-					nodesLabels:          []map[string]string{nodeLabelsWithRTKernel},
-					clusterVersion:       clusterVersion,
-					clusterReleaseImages: clusterReleaseImages,
-					dtkImage:             dtkImageURL,
-					dtk:                  clusterDTK,
+					nodesLabels:    []map[string]string{nodeLabelsWithRTKernel},
+					clusterVersion: clusterVersion,
+					dtkImages:      dtkImages,
+					dtk:            clusterDTK,
 				},
 				map[string]NodeVersion{
 					kernelRT: {
@@ -144,7 +139,7 @@ var _ = Describe("ClusterInfo", func() {
 						OSMajorMinor:   fmt.Sprintf("%s%s.%s", system, systemMajor, systemMinor),
 						ClusterVersion: clusterVersion,
 						DriverToolkit: registry.DriverToolkitEntry{
-							ImageURL:            dtkImageURL,
+							ImageURL:            dtkImages[0],
 							KernelFullVersion:   kernel,
 							RTKernelFullVersion: kernelRT,
 							OSVersion:           fmt.Sprintf("%s.%s", systemMajor, systemMinor),
@@ -156,11 +151,10 @@ var _ = Describe("ClusterInfo", func() {
 			Entry(
 				"1 node with non-RT kernel",
 				testInput{
-					nodesLabels:          []map[string]string{nodeLabelsWithRegularKernel},
-					clusterVersion:       clusterVersion,
-					clusterReleaseImages: clusterReleaseImages,
-					dtkImage:             dtkImageURL,
-					dtk:                  clusterDTK,
+					nodesLabels:    []map[string]string{nodeLabelsWithRegularKernel},
+					clusterVersion: clusterVersion,
+					dtkImages:      dtkImages,
+					dtk:            clusterDTK,
 				},
 				map[string]NodeVersion{
 					kernel: {
@@ -169,7 +163,7 @@ var _ = Describe("ClusterInfo", func() {
 						OSMajorMinor:   fmt.Sprintf("%s%s.%s", system, systemMajor, systemMinor),
 						ClusterVersion: clusterVersion,
 						DriverToolkit: registry.DriverToolkitEntry{
-							ImageURL:            dtkImageURL,
+							ImageURL:            dtkImages[0],
 							KernelFullVersion:   kernel,
 							RTKernelFullVersion: kernelRT,
 							OSVersion:           fmt.Sprintf("%s.%s", systemMajor, systemMinor),
@@ -185,10 +179,9 @@ var _ = Describe("ClusterInfo", func() {
 						nodeLabelsWithRTKernel,
 						nodeLabelsWithRegularKernel,
 					},
-					clusterVersion:       clusterVersion,
-					clusterReleaseImages: clusterReleaseImages,
-					dtkImage:             dtkImageURL,
-					dtk:                  clusterDTK,
+					clusterVersion: clusterVersion,
+					dtkImages:      dtkImages,
+					dtk:            clusterDTK,
 				},
 				map[string]NodeVersion{
 					kernel: {
@@ -197,7 +190,7 @@ var _ = Describe("ClusterInfo", func() {
 						OSMajorMinor:   fmt.Sprintf("%s%s.%s", system, systemMajor, systemMinor),
 						ClusterVersion: clusterVersion,
 						DriverToolkit: registry.DriverToolkitEntry{
-							ImageURL:            dtkImageURL,
+							ImageURL:            dtkImages[0],
 							KernelFullVersion:   kernel,
 							RTKernelFullVersion: kernelRT,
 							OSVersion:           fmt.Sprintf("%s.%s", systemMajor, systemMinor),
@@ -209,7 +202,7 @@ var _ = Describe("ClusterInfo", func() {
 						OSMajorMinor:   fmt.Sprintf("%s%s.%s", system, systemMajor, systemMinor),
 						ClusterVersion: clusterVersion,
 						DriverToolkit: registry.DriverToolkitEntry{
-							ImageURL:            dtkImageURL,
+							ImageURL:            dtkImages[0],
 							KernelFullVersion:   kernel,
 							RTKernelFullVersion: kernelRT,
 							OSVersion:           fmt.Sprintf("%s.%s", systemMajor, systemMinor),
@@ -248,10 +241,8 @@ var _ = Describe("ClusterInfo", func() {
 
 			ctx := context.TODO()
 
-			mockCluster.EXPECT().VersionHistory(ctx).Return(input.clusterReleaseImages, nil)
-			mockRegistry.EXPECT().LastLayer(ctx, input.clusterReleaseImages[0]).Return(&fakeLayer{}, nil)
-			mockRegistry.EXPECT().ReleaseManifests(gomock.Any()).Return(input.clusterVersion, input.dtkImage, nil)
-			mockRegistry.EXPECT().LastLayer(ctx, input.dtkImage).Return(&fakeLayer{}, nil)
+			mockCluster.EXPECT().GetDTKImages(ctx).Return(input.dtkImages, nil)
+			mockRegistry.EXPECT().LastLayer(ctx, input.dtkImages[0]).Return(&fakeLayer{}, nil)
 			mockRegistry.EXPECT().ExtractToolkitRelease(gomock.Any()).Return(input.dtk, nil)
 
 			m, err := clusterInfo.GetClusterInfo(ctx, &nodesList)
@@ -262,33 +253,30 @@ var _ = Describe("ClusterInfo", func() {
 			Entry(
 				"Mismatched OS with regular kernel",
 				testInput{
-					nodesLabels:          []map[string]string{badNodeOSLabelsWithRegularKernel},
-					clusterVersion:       clusterVersion,
-					clusterReleaseImages: clusterReleaseImages,
-					dtkImage:             dtkImageURL,
-					dtk:                  clusterDTK,
+					nodesLabels:    []map[string]string{badNodeOSLabelsWithRegularKernel},
+					clusterVersion: clusterVersion,
+					dtkImages:      dtkImages,
+					dtk:            clusterDTK,
 				},
 				fmt.Errorf("OSVersion mismatch NFD: %s.%s vs. DTK: %s.%s", systemMajor, badSystemMinor, systemMajor, systemMinor),
 			),
 			Entry(
 				"Mismatched OS with RT kernel",
 				testInput{
-					nodesLabels:          []map[string]string{badNodeOSLabelsWithRTKernel},
-					clusterVersion:       clusterVersion,
-					clusterReleaseImages: clusterReleaseImages,
-					dtkImage:             dtkImageURL,
-					dtk:                  clusterDTK,
+					nodesLabels:    []map[string]string{badNodeOSLabelsWithRTKernel},
+					clusterVersion: clusterVersion,
+					dtkImages:      dtkImages,
+					dtk:            clusterDTK,
 				},
 				fmt.Errorf("OSVersion mismatch NFD: %s.%s vs. DTK: %s.%s", systemMajor, badSystemMinor, systemMajor, systemMinor),
 			),
 			Entry(
 				"Mismatched kernel between nodes and DTK",
 				testInput{
-					nodesLabels:          []map[string]string{badNodeLabelsNoKernelMatch},
-					clusterVersion:       clusterVersion,
-					clusterReleaseImages: clusterReleaseImages,
-					dtkImage:             dtkImageURL,
-					dtk:                  clusterDTK,
+					nodesLabels:    []map[string]string{badNodeLabelsNoKernelMatch},
+					clusterVersion: clusterVersion,
+					dtkImages:      dtkImages,
+					dtk:            clusterDTK,
 				},
 				fmt.Errorf("DTK kernel not found running in the cluster. kernelFullVersion: %s. rtKernelFullVersion: %s", kernel, kernelRT),
 			),
@@ -322,7 +310,7 @@ var _ = Describe("ClusterInfo", func() {
 					OSMajorMinor:   fmt.Sprintf("%s%s.%s", system, systemMajor, systemMinor),
 					ClusterVersion: clusterVersion,
 					DriverToolkit: registry.DriverToolkitEntry{
-						ImageURL:            dtkImageURL,
+						ImageURL:            dtkImages[0],
 						KernelFullVersion:   kernel,
 						RTKernelFullVersion: kernelRT,
 						OSVersion:           fmt.Sprintf("%s.%s", systemMajor, systemMinor),
@@ -338,10 +326,8 @@ var _ = Describe("ClusterInfo", func() {
 
 			ctx := context.TODO()
 
-			mockCluster.EXPECT().VersionHistory(ctx).Return(clusterReleaseImages, nil)
-			mockRegistry.EXPECT().LastLayer(ctx, clusterReleaseImages[0]).Return(&fakeLayer{}, nil)
-			mockRegistry.EXPECT().ReleaseManifests(gomock.Any()).Return(clusterVersion, dtkImageURL, nil)
-			mockRegistry.EXPECT().LastLayer(ctx, dtkImageURL).Return(&fakeLayer{}, nil)
+			mockCluster.EXPECT().GetDTKImages(ctx).Return(dtkImages, nil)
+			mockRegistry.EXPECT().LastLayer(ctx, dtkImages[0]).Return(&fakeLayer{}, nil)
 			mockRegistry.EXPECT().ExtractToolkitRelease(gomock.Any()).Return(clusterDTK, nil)
 
 			m, err := clusterInfo.GetClusterInfo(ctx, &nodesList)
@@ -351,10 +337,8 @@ var _ = Describe("ClusterInfo", func() {
 				Expect(m).To(HaveKeyWithValue(expectedKernel, expectedNodeVersion))
 			}
 			// after first execution it is cached, therefore no more calls to mocks.
-			mockCluster.EXPECT().VersionHistory(ctx).Return(clusterReleaseImages, nil)
-			mockRegistry.EXPECT().LastLayer(ctx, clusterReleaseImages[0]).Times(0)
-			mockRegistry.EXPECT().ReleaseManifests(gomock.Any()).Times(0)
-			mockRegistry.EXPECT().LastLayer(ctx, dtkImageURL).Times(0)
+			mockCluster.EXPECT().GetDTKImages(ctx).Return(dtkImages, nil)
+			mockRegistry.EXPECT().LastLayer(ctx, dtkImages[0]).Times(0)
 			mockRegistry.EXPECT().ExtractToolkitRelease(gomock.Any()).Times(0)
 
 			m, err = clusterInfo.GetClusterInfo(ctx, &nodesList)


### PR DESCRIPTION
Instead of fetching and unpacking release image to get the DTK Image URL, a `driver-toolkit` `ImageStream` is used.