### PR TITLE
MGMT-9193: Create metric for upgrade alert

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -11,6 +11,7 @@ const (
 	completedStatesQuery         = "sro_states_completed_info"
 	completedKindQuery           = "sro_kind_completed_info"
 	usedNodesQuery               = "sro_used_nodes"
+	upgradeAlertQuery            = "sro_upgrade_alert"
 )
 
 var (
@@ -42,6 +43,14 @@ var (
 		},
 		[]string{"cr", "kind", "name", "namespace", "nodes"},
 	)
+
+	upgradeAlert = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: upgradeAlertQuery,
+			Help: "For a SRO CR, 1 if during upgrade there is a problem with CR, 0 otherwise",
+		},
+		[]string{"cr"},
+	)
 )
 
 func init() {
@@ -51,6 +60,7 @@ func init() {
 		createdSpecialResources,
 		completedKinds,
 		usedNodes,
+		upgradeAlert,
 	)
 }
 
@@ -62,6 +72,7 @@ type Metrics interface {
 	SetCompletedState(specialResource, state string, value int)
 	SetCompletedKind(specialResource, kind, name, namespace string, value int)
 	SetUsedNodes(crName, kind, name, namespace, nodes string)
+	SetUpgradeAlert(crName string, value int)
 }
 
 func New() Metrics {
@@ -84,4 +95,8 @@ func (m *metricsImpl) SetCompletedKind(specialResource, kind, name, namespace st
 
 func (m *metricsImpl) SetUsedNodes(crName, kind, name, namespace, nodes string) {
 	usedNodes.WithLabelValues(crName, kind, name, namespace, nodes).Set(float64(1))
+}
+
+func (m *metricsImpl) SetUpgradeAlert(crName string, value int) {
+	upgradeAlert.WithLabelValues(crName).Set(float64(value))
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -15,6 +15,7 @@ const (
 	completedStatesValue       = 2
 	completedKindValue         = 2
 	usedNodesValue             = 1
+	upgradeAlertValue          = 1
 
 	sr         = "simple-kmod"
 	state      = "templates/0000-buildconfig.yaml"
@@ -44,6 +45,7 @@ var _ = Describe("Metrics", func() {
 	m.SetCompletedState(sr, state, completedStatesValue)
 	m.SetCompletedKind(sr, kind, name, namespace, completedKindValue)
 	m.SetUsedNodes(sr, kind, name, namespace, nodes_list)
+	m.SetUpgradeAlert(sr, upgradeAlertValue)
 
 	It("correctly passes calls to the collectors", func() {
 		expected := []struct {
@@ -54,6 +56,7 @@ var _ = Describe("Metrics", func() {
 			{completedStatesQuery, completedStatesValue},
 			{completedKindQuery, completedKindValue},
 			{usedNodesQuery, usedNodesValue},
+			{upgradeAlertQuery, upgradeAlertValue},
 		}
 
 		data, err := metrics.Registry.Gather()

--- a/pkg/metrics/mock_metrics_api.go
+++ b/pkg/metrics/mock_metrics_api.go
@@ -69,6 +69,18 @@ func (mr *MockMetricsMockRecorder) SetSpecialResourcesCreated(value interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSpecialResourcesCreated", reflect.TypeOf((*MockMetrics)(nil).SetSpecialResourcesCreated), value)
 }
 
+// SetUpgradeAlert mocks base method.
+func (m *MockMetrics) SetUpgradeAlert(crName string, value int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetUpgradeAlert", crName, value)
+}
+
+// SetUpgradeAlert indicates an expected call of SetUpgradeAlert.
+func (mr *MockMetricsMockRecorder) SetUpgradeAlert(crName, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeAlert", reflect.TypeOf((*MockMetrics)(nil).SetUpgradeAlert), crName, value)
+}
+
 // SetUsedNodes mocks base method.
 func (m *MockMetrics) SetUsedNodes(crName, kind, name, namespace, nodes string) {
 	m.ctrl.T.Helper()

--- a/pkg/resource/mock_resource_api.go
+++ b/pkg/resource/mock_resource_api.go
@@ -10,7 +10,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // MockCreator is a mock of Creator interface.
@@ -34,20 +33,6 @@ func NewMockCreator(ctrl *gomock.Controller) *MockCreator {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCreator) EXPECT() *MockCreatorMockRecorder {
 	return m.recorder
-}
-
-// CheckForImagePullBackOff mocks base method.
-func (m *MockCreator) CheckForImagePullBackOff(arg0 context.Context, arg1 *unstructured.Unstructured, arg2 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckForImagePullBackOff", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CheckForImagePullBackOff indicates an expected call of CheckForImagePullBackOff.
-func (mr *MockCreatorMockRecorder) CheckForImagePullBackOff(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckForImagePullBackOff", reflect.TypeOf((*MockCreator)(nil).CheckForImagePullBackOff), arg0, arg1, arg2)
 }
 
 // CreateFromYAML mocks base method.


### PR DESCRIPTION
Define and create a metric that will be later used by the "pre-flight"
upgrade code to trigger alert in case SRO encounters a problem with
driver-container for a specific CR