### PR TITLE
MGMT-9231: deployment of PrometheusRule for upgrade alert

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -48,3 +48,23 @@ subjects:
   - kind: ServiceAccount
     name: prometheus-k8s
     namespace: openshift-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    role: alert-rules
+  name: sro-operator-prometheus-rules
+  namespace: openshift-special-resource-operator
+spec:
+  groups:
+  - name: sro-operator.rules
+    rules:
+    - alert: UpgradeWarning
+      annotations:
+        message: |
+          Current upgrade may cause driver-container in CR {{ $labels.cr }} to fail.
+      expr: sro_upgrade_alert == 1
+      for: 1m
+      labels:
+        severity: warning


### PR DESCRIPTION
Define and deploy PrometheusRule that uses the sro_upgrade_metric
to raise an alert, in case it is needed