### PR TITLE
Remove callback annotations

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -30,11 +30,8 @@ import (
 	"github.com/openshift-psap/special-resource-operator/pkg/yamlutil"
 )
 
-type resourceCallbacks map[string]func(obj *unstructured.Unstructured, sr interface{}) error
-
 var (
-	customCallback = make(resourceCallbacks)
-	UpdateVendor   string
+	UpdateVendor string
 )
 
 //go:generate mockgen -source=resource.go -package=resource -destination=mock_resource_api.go
@@ -485,24 +482,10 @@ func (c *creator) sendNodesMetrics(ctx context.Context, obj *unstructured.Unstru
 }
 
 func (c *creator) BeforeCRUD(obj *unstructured.Unstructured, sr interface{}) error {
-
-	var found bool
-	todo := ""
 	annotations := obj.GetAnnotations()
-
 	if valid, found := annotations["specialresource.openshift.io/proxy"]; found && valid == "true" {
 		if err := c.proxyAPI.Setup(obj); err != nil {
 			return fmt.Errorf("could not setup Proxy: %w", err)
-		}
-	}
-
-	if todo, found = annotations["specialresource.openshift.io/callback"]; !found {
-		return nil
-	}
-
-	if prefix, ok := customCallback[todo]; ok {
-		if err := prefix(obj, sr); err != nil {
-			return fmt.Errorf("could not run prefix callback: %w", err)
 		}
 	}
 	return nil

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -478,25 +478,6 @@ var _ = Describe("creator_BeforeCRUD", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should execute callback if a callback annotation is present", func() {
-		callbackName := "test_callback"
-		callbackCalled := false
-		customCallback[callbackName] = func(obj *unstructured.Unstructured, sr interface{}) error {
-			callbackCalled = true
-			return nil
-		}
-
-		obj := &unstructured.Unstructured{}
-		obj.SetAnnotations(map[string]string{
-			"specialresource.openshift.io/callback": callbackName,
-		})
-
-		err := NewCreator(nil, nil, nil, nil, nil, nil, proxyAPI, nil).(*creator).
-			BeforeCRUD(obj, nil)
-
-		Expect(err).ToNot(HaveOccurred())
-		Expect(callbackCalled).To(BeTrue())
-	})
 })
 
 var _ = Describe("creator_AfterCRUD", func() {


### PR DESCRIPTION
Remove callback annotations from recipes, as it requires custom code in SRO and right now there arent any. This is currently dead code.

Callbacks may be superseded by helm hooks.