### PR TITLE
Use in-memory pull-secret instead of writing to disk

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -57,12 +57,8 @@ spec:
           volumeMounts:
           - name: cache-volume
             mountPath: /cache
-          - name: cred-volume
-            mountPath: /home/nonroot/.docker
       volumes:
         - name: cache-volume
-          emptyDir: {}
-        - name: cred-volume
           emptyDir: {}
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/manifests-k8s/0013_deployment_special-resource-controller-manager.yaml
+++ b/manifests-k8s/0013_deployment_special-resource-controller-manager.yaml
@@ -45,8 +45,6 @@ spec:
         volumeMounts:
         - mountPath: /cache
           name: cache-volume
-        - mountPath: /home/nonroot/.docker
-          name: cred-volume
       securityContext:
         runAsGroup: 499
         runAsNonRoot: true
@@ -56,5 +54,3 @@ spec:
       volumes:
       - emptyDir: {}
         name: cache-volume
-      - emptyDir: {}
-        name: cred-volume

--- a/manifests/0015_deployment_special-resource-controller-manager.yaml
+++ b/manifests/0015_deployment_special-resource-controller-manager.yaml
@@ -72,8 +72,6 @@ spec:
         volumeMounts:
         - mountPath: /cache
           name: cache-volume
-        - mountPath: /home/nonroot/.docker
-          name: cred-volume
       securityContext:
         runAsGroup: 499
         runAsNonRoot: true
@@ -86,5 +84,3 @@ spec:
           secretName: special-resource-operator-tls
       - emptyDir: {}
         name: cache-volume
-      - emptyDir: {}
-        name: cred-volume

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -74,22 +74,16 @@ func (r *registry) registryFromImageURL(image string) (string, error) {
 	}
 
 	if err != nil || u.Host == "" {
-		return "", errors.New("Failed to parse image url: " + image)
+		return "", fmt.Errorf("failed to parse image url: %s", image)
 	}
 
 	return u.Host, nil
 }
 
 func (r *registry) getImageRegistryCredentials(ctx context.Context, registry string) (dockerAuth, error) {
-	_, err := r.kubeClient.GetNamespace(ctx, pullSecretNamespace, metav1.GetOptions{})
-	if err != nil {
-		r.log.Info("Can not find namespace for pull secrets, assuming vanilla k8s")
-		return dockerAuth{}, nil
-	}
-
 	s, err := r.kubeClient.GetSecret(ctx, pullSecretNamespace, pullSecretName, metav1.GetOptions{})
 	if err != nil {
-		return dockerAuth{}, errors.Wrap(err, "Can not retrieve pull secrets")
+		return dockerAuth{}, errors.Wrap(err, "could not retrieve pull secrets")
 	}
 
 	pullSecretData, ok := s.Data[pullSecretFileName]

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -94,7 +94,7 @@ func (r *registry) getImageRegistryCredentials(ctx context.Context, registry str
 
 	pullSecretData, ok := s.Data[pullSecretFileName]
 	if !ok {
-		return dockerAuth{}, errors.New("Can not find data content in the secret")
+		return dockerAuth{}, errors.New("could not find data content in the secret")
 	}
 
 	auths := struct {
@@ -103,11 +103,11 @@ func (r *registry) getImageRegistryCredentials(ctx context.Context, registry str
 
 	err = json.Unmarshal(pullSecretData, &auths)
 	if err != nil {
-		return dockerAuth{}, errors.New("Failed to unmarshal auths")
+		return dockerAuth{}, errors.New("failed to unmarshal auths")
 	}
 
 	if auth, ok := auths.Auths[registry]; !ok {
-		return dockerAuth{}, errors.New("Cluster PullSecret does not contain auth for the registry " + registry)
+		return dockerAuth{}, fmt.Errorf("cluster PullSecret does not contain auth for registry %s", registry)
 	} else {
 		return auth, nil
 	}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,94 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/openshift-psap/special-resource-operator/pkg/clients"
+)
+
+func TestRegistry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Registry Suite")
+}
+
+var _ = Describe("registryFromImageURL", func() {
+	DescribeTable("should parse URLs as expected",
+		func(image, expectedHost string) {
+			r := registry{}
+			host, err := r.registryFromImageURL(image)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(host).To(Equal(expectedHost))
+		},
+		Entry(nil, "registry.io/org/repo@sha256:123", "registry.io"),
+		Entry(nil, "//another-registry.io/org/repo@sha256:987", "another-registry.io"),
+	)
+})
+
+var _ = Describe("getImageRegistryCredentials", func() {
+	const (
+		expectedNamespace = "openshift-config"
+		expectedName      = "pull-secret"
+		expectedFile      = ".dockerconfigjson"
+		url               = "registry.io"
+		auth              = "123"
+		email             = "user@" + url
+	)
+
+	config := fmt.Sprintf(`{"auths":{"%s":{"auth":"%s","email":"%s"}}}`, url, auth, email)
+
+	var (
+		kubeClient *clients.MockClientsInterface
+		r          Registry
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		kubeClient = clients.NewMockClientsInterface(ctrl)
+		r = NewRegistry(kubeClient)
+	})
+
+	DescribeTable("should fail in following scenarios",
+		func(secret *v1.Secret, getError error, url string, expectedErrorStr string) {
+			kubeClient.EXPECT().
+				GetSecret(context.Background(), expectedNamespace, expectedName, gomock.Any()).
+				Return(secret, getError)
+
+			_, err := r.(*registry).getImageRegistryCredentials(context.Background(), url)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(expectedErrorStr))
+		},
+		Entry("no pull-secret in the cluster",
+			nil, errors.New(""), url,
+			"could not retrieve pull secrets"),
+		Entry("pull-secret has no data",
+			&v1.Secret{}, nil, url,
+			"could not find data"),
+		Entry("pull-secret doesn't have an entry for requested host",
+			&v1.Secret{Data: map[string][]byte{expectedFile: []byte(config)}}, nil, "other-registry.io",
+			"does not contain auth for registry"),
+	)
+
+	It("will work for expected scenario", func() {
+		pullSecret := &v1.Secret{
+			Data: map[string][]byte{
+				expectedFile: []byte(config),
+			},
+		}
+		kubeClient.EXPECT().
+			GetSecret(context.Background(), expectedNamespace, expectedName, gomock.Any()).
+			Return(pullSecret, nil)
+
+		da, err := r.(*registry).getImageRegistryCredentials(context.Background(), url)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(da).To(Equal(dockerAuth{Auth: auth, Email: email}))
+	})
+})


### PR DESCRIPTION
Using pull secret in-memory makes running the operator easier in out-of-cluster scenario (using `go run .` against `$KUBECONFIG`)