### PR TITLE
OCPBUGSM-39968 Fix bug in make bundle-push to use local-image-push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ bundle-build: ## Build the bundle image.
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
-	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
+	$(MAKE) local-image-push IMG=$(BUNDLE_IMG)
 
 .PHONY: opm
 OPM = ./bin/opm


### PR DESCRIPTION
This PR fixes issue described in https://github.com/openshift/special-resource-operator/issues/93. bundle-push target in Makefile refers to docker-push and should do to local-image-push to push the bundle image.
