### PR TITLE
Remove wait from poll package

### DIFF
--- a/pkg/poll/poll_test.go
+++ b/pkg/poll/poll_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -21,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	restclient "k8s.io/client-go/rest"
 	fakerestclient "k8s.io/client-go/rest/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,9 +49,6 @@ func TestPoll(t *testing.T) {
 		mockLifecycle = lifecycle.NewMockLifecycle(ctrl)
 		mockStorage = storage.NewMockStorage(ctrl)
 		pa = New(mockClientsInterface, mockLifecycle, mockStorage)
-
-		retryInterval = time.Millisecond * 5
-		timeout = time.Millisecond * 30
 	})
 
 	RunSpecs(t, "PollActions Suite")
@@ -355,7 +350,6 @@ var _ = Context("Waiting for DaemonSet", func() {
 
 			err := pa.ForDaemonSet(context.Background(), obj)
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(BeEquivalentTo(wait.ErrWaitTimeout))
 		})
 	})
 
@@ -537,7 +531,7 @@ var _ = Context("Polling for resource unavailability", func() {
 			"object exists",
 			nil,
 			func(err error) {
-				Expect(err).To(BeEquivalentTo(wait.ErrWaitTimeout))
+				Expect(err).To(HaveOccurred())
 			}),
 		Entry(
 			"another error occurs",


### PR DESCRIPTION
Remove wait calls from poll package.

Reconciliation loop goes through all yaml files in a helm chart, each of them having the following waiting pattern:
- Wait 5s before doing any checks.
- Check if the resource is available (whatever that is for different resources).
- If it is, return error-free and continue with the next file.
- If not, retry after 5 additional seconds.
- Repeat until 30s mark is reached and return an error.

This means that each file will introduce a significant delay in the loop, preventing other SRs to progress and, in general, taking too long to execute each one.

This PR drops all waiting and replaces them with immediate checks with reconcile errors to allow concurrency. Results of the change are high speedups when reconciling, plus improved responsiveness.