### PR TITLE
Use helm libraries as client only

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func main() {
 
 	clusterInfoAPI := upgrade.NewClusterInfo(registry.NewRegistry(kubeClient), clusterAPI)
 	runtimeAPI := runtime.NewRuntimeAPI(kubeClient, clusterAPI, kernelAPI, clusterInfoAPI, proxyAPI)
-	helmerAPI, err := helmer.NewHelmer(creator, helmer.DefaultSettings(), kubeClient)
+	helmerAPI, err := helmer.NewHelmer(creator, helmSettings, kubeClient)
 	if err != nil {
 		setupLog.Error(err, "Unable to setup helmer")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -133,6 +133,11 @@ func main() {
 
 	clusterInfoAPI := upgrade.NewClusterInfo(registry.NewRegistry(kubeClient), clusterAPI)
 	runtimeAPI := runtime.NewRuntimeAPI(kubeClient, clusterAPI, kernelAPI, clusterInfoAPI, proxyAPI)
+	helmerAPI, err := helmer.NewHelmer(creator, helmer.DefaultSettings(), kubeClient)
+	if err != nil {
+		setupLog.Error(err, "Unable to setup helmer")
+		os.Exit(1)
+	}
 
 	if err = (&controllers.SpecialResourceReconciler{Cluster: clusterAPI,
 		ClusterInfo:            clusterInfoAPI,
@@ -143,7 +148,7 @@ func main() {
 		Finalizer:              finalizers.NewSpecialResourceFinalizer(kubeClient, pollActions),
 		StatusUpdater:          state.NewStatusUpdater(kubeClient),
 		Storage:                st,
-		Helmer:                 helmer.NewHelmer(creator, helmSettings, kubeClient),
+		Helmer:                 helmerAPI,
 		Assets:                 assets.NewAssets(),
 		KernelData:             kernelAPI,
 		Log:                    ctrl.Log,

--- a/main.go
+++ b/main.go
@@ -81,12 +81,6 @@ func main() {
 		"GOMAXPROCS", os.Getenv("GOMAXPROCS"),
 	)
 
-	helmSettings, err := helmer.DefaultSettings()
-	if err != nil {
-		setupLog.Error(err, "failed to create Helm settings")
-		os.Exit(1)
-	}
-
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	opts := &ctrl.Options{
@@ -133,7 +127,8 @@ func main() {
 
 	clusterInfoAPI := upgrade.NewClusterInfo(registry.NewRegistry(kubeClient), clusterAPI)
 	runtimeAPI := runtime.NewRuntimeAPI(kubeClient, clusterAPI, kernelAPI, clusterInfoAPI, proxyAPI)
-	helmerAPI, err := helmer.NewHelmer(creator, helmSettings, kubeClient)
+
+	helmerAPI, err := helmer.NewHelmer(creator, kubeClient)
 	if err != nil {
 		setupLog.Error(err, "Unable to setup helmer")
 		os.Exit(1)

--- a/pkg/helmer/helmer.go
+++ b/pkg/helmer/helmer.go
@@ -19,6 +19,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/release"
@@ -72,9 +73,24 @@ type helmer struct {
 	kubeClient      clients.ClientsInterface
 	repoFile        *repo.File
 	settings        *cli.EnvSettings
+	kubeVersion     chartutil.KubeVersion
+	apiVersions     chartutil.VersionSet
 }
 
-func NewHelmer(creator resource.Creator, settings *cli.EnvSettings, kubeClient clients.ClientsInterface) *helmer {
+func NewHelmer(creator resource.Creator, settings *cli.EnvSettings, kubeClient clients.ClientsInterface) (*helmer, error) {
+	dc, err := settings.RESTClientGetter().ToDiscoveryClient()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get discovery client: %w", err)
+	}
+	dc.Invalidate()
+	kubeVersion, err := dc.ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve server version: %w", err)
+	}
+	apiVersions, err := action.GetVersionSet(dc)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve API versions: %w", err)
+	}
 	return &helmer{
 		creator:         creator,
 		getterProviders: getter.All(settings),
@@ -86,7 +102,13 @@ func NewHelmer(creator resource.Creator, settings *cli.EnvSettings, kubeClient c
 			Repositories: []*repo.Entry{},
 		},
 		settings: settings,
-	}
+		kubeVersion: chartutil.KubeVersion{
+			Version: kubeVersion.GitVersion,
+			Major:   kubeVersion.Major,
+			Minor:   kubeVersion.Minor,
+		},
+		apiVersions: apiVersions,
+	}, nil
 }
 
 func init() {
@@ -247,8 +269,9 @@ func (h *helmer) Run(
 	install.DryRun = true
 	install.ReleaseName = ch.Metadata.Name
 	install.Replace = false
-	install.ClientOnly = false
-	install.APIVersions = []string{}
+	install.ClientOnly = true
+	install.KubeVersion = &h.kubeVersion
+	install.APIVersions = h.apiVersions
 	install.IncludeCRDs = false
 	install.Namespace = namespace
 	install.DisableHooks = false
@@ -261,16 +284,6 @@ func (h *helmer) Run(
 
 	if ch.Metadata.Type != "" && ch.Metadata.Type != "application" {
 		return fmt.Errorf("Chart has an unsupported type %s and can not be installed", ch.Metadata.Type)
-	}
-
-	// Pre-install anything in the crd/ directory. We do this before Helm
-	// contacts the upstream server and builds the capabilities object.
-	if crds := ch.CRDObjects(); !install.ClientOnly && !install.SkipCRDs && len(crds) > 0 {
-
-		err := h.InstallCRDs(ctx, crds, owner, install.ReleaseName, install.Namespace)
-		if err != nil {
-			return fmt.Errorf("Cannot install CRDs: %w", err)
-		}
 	}
 
 	rel, err := install.Run(&ch, vals)
@@ -298,6 +311,15 @@ func (h *helmer) Run(
 		// not working.
 		utils.WarnOnError(err)
 		//return err
+	}
+
+	// Pre-install anything in the crd/ directory.
+	if crds := ch.CRDObjects(); len(crds) > 0 {
+
+		err := h.InstallCRDs(ctx, crds, owner, install.ReleaseName, install.Namespace)
+		if err != nil {
+			return fmt.Errorf("cannot install CRDs: %w", err)
+		}
 	}
 
 	// pre-install hooks

--- a/pkg/helmer/helmer_test.go
+++ b/pkg/helmer/helmer_test.go
@@ -1,4 +1,4 @@
-package helmer_test
+package helmer
 
 import (
 	"context"
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/special-resource-operator/pkg/clients"
-	"github.com/openshift/special-resource-operator/pkg/helmer"
 	"github.com/openshift/special-resource-operator/pkg/resource"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/cli"
@@ -50,7 +49,7 @@ var _ = Describe("helmer_InstallCRDs", func() {
 			CreateFromYAML(context.TODO(), nil, false, owner, name, namespace, nil, "", "").
 			Return(randomError)
 
-		h, err := helmer.NewHelmer(mockCreator, cli.New(), mockKubeClient)
+		h, err := newHelmerWithVersions(mockCreator, cli.New(), nil, nil, mockKubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		err = h.InstallCRDs(context.TODO(), nil, owner, name, namespace)
 		Expect(err).To(Equal(randomError))
@@ -80,7 +79,7 @@ def
 			EXPECT().
 			CreateFromYAML(context.TODO(), manifests, false, owner, name, namespace, nil, "", "")
 
-		h, err := helmer.NewHelmer(mockCreator, cli.New(), mockKubeClient)
+		h, err := newHelmerWithVersions(mockCreator, cli.New(), nil, nil, mockKubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		err = h.InstallCRDs(context.TODO(), crds, owner, name, namespace)
 		Expect(err).NotTo(HaveOccurred())
@@ -103,7 +102,7 @@ var _ = Describe("helmer_Run", func() {
 			},
 		}
 
-		h, err := helmer.NewHelmer(mockCreator, cli.New(), mockKubeClient)
+		h, err := newHelmerWithVersions(mockCreator, cli.New(), nil, nil, mockKubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		err = h.Run(context.TODO(), ch, nil, owner, name, namespace, nil, "", "", false)
 		Expect(err).To(HaveOccurred())
@@ -129,7 +128,7 @@ var _ = Describe("helmer_Run", func() {
 			EXPECT().
 			CreateFromYAML(context.TODO(), gomock.Any(), false, owner, name, namespace, nil, "", "").
 			Return(randomError)
-		h, err := helmer.NewHelmer(mockCreator, cli.New(), mockKubeClient)
+		h, err := newHelmerWithVersions(mockCreator, cli.New(), nil, nil, mockKubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		err = h.Run(context.TODO(), ch, nil, owner, name, namespace, nil, "", "", false)
 		Expect(errors.Is(err, randomError)).To(BeTrue())

--- a/pkg/helmer/helmer_test.go
+++ b/pkg/helmer/helmer_test.go
@@ -50,7 +50,9 @@ var _ = Describe("helmer_InstallCRDs", func() {
 			CreateFromYAML(context.TODO(), nil, false, owner, name, namespace, nil, "", "").
 			Return(randomError)
 
-		err := helmer.NewHelmer(mockCreator, cli.New(), mockKubeClient).InstallCRDs(context.TODO(), nil, owner, name, namespace)
+		h, err := helmer.NewHelmer(mockCreator, cli.New(), mockKubeClient)
+		Expect(err).NotTo(HaveOccurred())
+		err = h.InstallCRDs(context.TODO(), nil, owner, name, namespace)
 		Expect(err).To(Equal(randomError))
 	})
 
@@ -78,7 +80,9 @@ def
 			EXPECT().
 			CreateFromYAML(context.TODO(), manifests, false, owner, name, namespace, nil, "", "")
 
-		err := helmer.NewHelmer(mockCreator, cli.New(), mockKubeClient).InstallCRDs(context.TODO(), crds, owner, name, namespace)
+		h, err := helmer.NewHelmer(mockCreator, cli.New(), mockKubeClient)
+		Expect(err).NotTo(HaveOccurred())
+		err = h.InstallCRDs(context.TODO(), crds, owner, name, namespace)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
@@ -99,9 +103,9 @@ var _ = Describe("helmer_Run", func() {
 			},
 		}
 
-		err := helmer.
-			NewHelmer(mockCreator, cli.New(), mockKubeClient).
-			Run(context.TODO(), ch, nil, owner, name, namespace, nil, "", "", false)
+		h, err := helmer.NewHelmer(mockCreator, cli.New(), mockKubeClient)
+		Expect(err).NotTo(HaveOccurred())
+		err = h.Run(context.TODO(), ch, nil, owner, name, namespace, nil, "", "", false)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -125,10 +129,9 @@ var _ = Describe("helmer_Run", func() {
 			EXPECT().
 			CreateFromYAML(context.TODO(), gomock.Any(), false, owner, name, namespace, nil, "", "").
 			Return(randomError)
-
-		err := helmer.
-			NewHelmer(mockCreator, cli.New(), mockKubeClient).
-			Run(context.TODO(), ch, nil, owner, name, namespace, nil, "", "", false)
+		h, err := helmer.NewHelmer(mockCreator, cli.New(), mockKubeClient)
+		Expect(err).NotTo(HaveOccurred())
+		err = h.Run(context.TODO(), ch, nil, owner, name, namespace, nil, "", "", false)
 		Expect(errors.Is(err, randomError)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
Shaves around ~10s from each reconciliation loop.

Helm is used to dry run an install to generate all manifests for later apply in an ordered fashion from SRO. Among the options for the install we have `ClientOnly` set to false. If we look at how helm uses this parameter we find (assuming it is set to false):
- Install config runs using `DryRun`, meaning no actual resources will be created.
- When setting `ClientOnly` to false helm uses an actual kubeclient to talk to the cluster.
- CRDs get installed if not using `DryRun`.
- Capabilities and API versions are retrieved from the cluster.
- Capabilities and API versions are passed to render manifests coalescing values.
- Check if resources already exist in the cluster.
- Dry run active, bail out.

Capabilities are a mixture of API versions and kubernetes version. These are used as part of the helm [values](https://github.com/helm/helm/blob/main/pkg/chartutil/values.go#L143) when rendering templates, like `{{ .Release.name }}`, for example.
When using `ClientOnly` this means the API versions are not retrieved from the cluster, and resources are not checked for existence either. Capabilities are filled either from default templates having the supported standard k8s resources, depending on helm version, or provided to the install config via attributes. We chose the latter, as the capabilities only change after upgrades and stay stable for the lifetime of SRO. When creating an instance of the `helmer` package all this data is retrieved for later use.