### PR TITLE
MGMT-9548: adding API to get DTK info based on DTK image

### DIFF
--- a/pkg/upgrade/mock_upgrade_api.go
+++ b/pkg/upgrade/mock_upgrade_api.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	registry "github.com/openshift-psap/special-resource-operator/pkg/registry"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -48,4 +49,19 @@ func (m *MockClusterInfo) GetClusterInfo(arg0 context.Context, arg1 *v1.NodeList
 func (mr *MockClusterInfoMockRecorder) GetClusterInfo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterInfo", reflect.TypeOf((*MockClusterInfo)(nil).GetClusterInfo), arg0, arg1)
+}
+
+// GetDTKData mocks base method.
+func (m *MockClusterInfo) GetDTKData(ctx context.Context, imageURL string) (*registry.DriverToolkitEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDTKData", ctx, imageURL)
+	ret0, _ := ret[0].(*registry.DriverToolkitEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDTKData indicates an expected call of GetDTKData.
+func (mr *MockClusterInfoMockRecorder) GetDTKData(ctx, imageURL interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDTKData", reflect.TypeOf((*MockClusterInfo)(nil).GetDTKData), ctx, imageURL)
 }

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -27,6 +27,7 @@ type NodeVersion struct {
 
 type ClusterInfo interface {
 	GetClusterInfo(context.Context, *corev1.NodeList) (map[string]NodeVersion, error)
+	GetDTKData(ctx context.Context, imageURL string) (*registry.DriverToolkitEntry, error)
 }
 
 func NewClusterInfo(reg registry.Registry, cluster cluster.Cluster) ClusterInfo {
@@ -146,8 +147,22 @@ func (ci *clusterInfo) driverToolkitVersion(ctx context.Context, dtkImages []str
 
 	var dtk *registry.DriverToolkitEntry
 	imageURL := dtkImages[0]
+	dtk, err := ci.GetDTKData(ctx, imageURL)
+	if err != nil {
+		return nil, err
+	}
+	// info has the kernels that are currently "running" on the cluster
+	// we're going only to update the struct with DTK information on
+	// running kernels and not on all that are found.
+	// We could have many entries with DTKs that are from an old update
+	// The objects that are kernel affine should only be replicated
+	// for valid kernels.
+	return ci.updateInfo(info, *dtk, imageURL)
+}
 
-	if dtk = ci.cache[imageURL]; dtk != nil {
+func (ci *clusterInfo) GetDTKData(ctx context.Context, imageURL string) (*registry.DriverToolkitEntry, error) {
+	dtk := ci.cache[imageURL]
+	if dtk != nil {
 		ci.log.Info("History from cache", "imageURL", imageURL, "dtk", dtk)
 	} else {
 		layer, err := ci.registry.LastLayer(ctx, imageURL)
@@ -166,11 +181,5 @@ func (ci *clusterInfo) driverToolkitVersion(ctx context.Context, dtkImages []str
 		ci.cache[imageURL] = dtk
 		ci.log.Info("History added to cache", "imageURL", imageURL, "dtk", dtk)
 	}
-	// info has the kernels that are currently "running" on the cluster
-	// we're going only to update the struct with DTK information on
-	// running kernels and not on all that are found.
-	// We could have many entries with DTKs that are from an old update
-	// The objects that are kernel affine should only be replicated
-	// for valid kernels.
-	return ci.updateInfo(info, *dtk, imageURL)
+	return dtk, nil
 }


### PR DESCRIPTION
This PR adds an API that allows to get an DTK info (full kernel, rt kernel etc')
encoded inside the DTK image