### PR TITLE
MGMT-9686: update package runtime for openshift downstream

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -108,7 +108,7 @@ func (rt *runtime) GetRuntimeInformation(ctx context.Context, sr *srov1beta1.Spe
 		KernelFullVersion:         "",
 		KernelPatchVersion:        "",
 		DriverToolkitImage:        "",
-		Platform:                  "",
+		Platform:                  "OCP",
 		ClusterVersion:            "",
 		ClusterVersionMajorMinor:  "",
 		ClusterUpgradeInfo:        make(map[string]upgrade.NodeVersion),
@@ -136,14 +136,6 @@ func (rt *runtime) GetRuntimeInformation(ctx context.Context, sr *srov1beta1.Spe
 	info.KernelPatchVersion, err = rt.kernelAPI.PatchVersion(info.KernelFullVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kernel patch version: %w", err)
-	}
-
-	// Only want to initialize the platform once.
-	if info.Platform == "" {
-		info.Platform, err = rt.kubeClient.GetPlatform()
-		if err != nil {
-			return nil, fmt.Errorf("failed to determine platform: %v", err)
-		}
 	}
 
 	info.ClusterVersion, info.ClusterVersionMajorMinor, err = rt.clusterAPI.Version(ctx)

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -136,7 +136,6 @@ var _ = Describe("GetRuntimeInformation", func() {
 		osDecimal := "osDecimal"
 		kernelFullVersion := "kernelFullVersion"
 		kernelPatchVersion := "kernelPatchVersion"
-		platform := "platform"
 		clusterVersion := "clusterVersion"
 		clusterVersionMajorMinor := "clusterMajorMinor"
 		clusterUpgradeInfo := map[string]upgrade.NodeVersion{"key": {}}
@@ -147,7 +146,6 @@ var _ = Describe("GetRuntimeInformation", func() {
 		mockCluster.EXPECT().OperatingSystem(&nodeList).Return(osMajor, osMajorMinor, osDecimal, nil)
 		mockKernel.EXPECT().FullVersion(&nodeList).Return(kernelFullVersion, nil)
 		mockKernel.EXPECT().PatchVersion(kernelFullVersion).Return(kernelPatchVersion, nil)
-		mockKubeClient.EXPECT().GetPlatform().Return(platform, nil)
 		mockCluster.EXPECT().Version(gomock.Any()).Return(clusterVersion, clusterVersionMajorMinor, nil)
 		mockClusterInfo.EXPECT().GetClusterInfo(gomock.Any(), &nodeList).Return(clusterUpgradeInfo, nil)
 		mockKubeClient.EXPECT().List(context.TODO(), secrets, optNs).
@@ -168,7 +166,7 @@ var _ = Describe("GetRuntimeInformation", func() {
 		Expect(runInfo.OperatingSystemDecimal).To(Equal(osDecimal))
 		Expect(runInfo.KernelFullVersion).To(Equal(kernelFullVersion))
 		Expect(runInfo.KernelPatchVersion).To(Equal(kernelPatchVersion))
-		Expect(runInfo.Platform).To(Equal(platform))
+		Expect(runInfo.Platform).To(Equal("OCP"))
 		Expect(runInfo.ClusterVersion).To(Equal(clusterVersion))
 		Expect(runInfo.ClusterVersionMajorMinor).To(Equal(clusterVersionMajorMinor))
 		Expect(runInfo.ClusterUpgradeInfo).To(Equal(clusterUpgradeInfo))


### PR DESCRIPTION
1) set platform to OCP (always)
2) remove checking the platfrom of the cluster