### PR TITLE
MGMT-9690: add OS configuration extraction from release image

### DIFF
--- a/pkg/registry/mock_registry_api.go
+++ b/pkg/registry/mock_registry_api.go
@@ -98,14 +98,28 @@ func (mr *MockRegistryMockRecorder) LastLayer(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastLayer", reflect.TypeOf((*MockRegistry)(nil).LastLayer), arg0, arg1)
 }
 
+// ReleaseImageMachineOSConfig mocks base method.
+func (m *MockRegistry) ReleaseImageMachineOSConfig(layer v1.Layer) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReleaseImageMachineOSConfig", layer)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReleaseImageMachineOSConfig indicates an expected call of ReleaseImageMachineOSConfig.
+func (mr *MockRegistryMockRecorder) ReleaseImageMachineOSConfig(layer interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseImageMachineOSConfig", reflect.TypeOf((*MockRegistry)(nil).ReleaseImageMachineOSConfig), layer)
+}
+
 // ReleaseManifests mocks base method.
-func (m *MockRegistry) ReleaseManifests(arg0 v1.Layer) (string, string, error) {
+func (m *MockRegistry) ReleaseManifests(arg0 v1.Layer) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseManifests", arg0)
 	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ReleaseManifests indicates an expected call of ReleaseManifests.

--- a/pkg/runtime/mock_runtime_api.go
+++ b/pkg/runtime/mock_runtime_api.go
@@ -36,41 +36,28 @@ func (m *MockRuntimeAPI) EXPECT() *MockRuntimeAPIMockRecorder {
 }
 
 // GetRuntimeInformation mocks base method.
-func (m *MockRuntimeAPI) GetRuntimeInformation(ctx context.Context, sr *v1beta1.SpecialResource, runInfo *RuntimeInformation) error {
+func (m *MockRuntimeAPI) GetRuntimeInformation(ctx context.Context, sr *v1beta1.SpecialResource) (*RuntimeInformation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRuntimeInformation", ctx, sr, runInfo)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetRuntimeInformation", ctx, sr)
+	ret0, _ := ret[0].(*RuntimeInformation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetRuntimeInformation indicates an expected call of GetRuntimeInformation.
-func (mr *MockRuntimeAPIMockRecorder) GetRuntimeInformation(ctx, sr, runInfo interface{}) *gomock.Call {
+func (mr *MockRuntimeAPIMockRecorder) GetRuntimeInformation(ctx, sr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRuntimeInformation", reflect.TypeOf((*MockRuntimeAPI)(nil).GetRuntimeInformation), ctx, sr, runInfo)
-}
-
-// InitRunInfo mocks base method.
-func (m *MockRuntimeAPI) InitRunInfo() RuntimeInformation {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitRunInfo")
-	ret0, _ := ret[0].(RuntimeInformation)
-	return ret0
-}
-
-// InitRunInfo indicates an expected call of InitRunInfo.
-func (mr *MockRuntimeAPIMockRecorder) InitRunInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitRunInfo", reflect.TypeOf((*MockRuntimeAPI)(nil).InitRunInfo))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRuntimeInformation", reflect.TypeOf((*MockRuntimeAPI)(nil).GetRuntimeInformation), ctx, sr)
 }
 
 // LogRuntimeInformation mocks base method.
-func (m *MockRuntimeAPI) LogRuntimeInformation(runInfo *RuntimeInformation) {
+func (m *MockRuntimeAPI) LogRuntimeInformation(info *RuntimeInformation) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "LogRuntimeInformation", runInfo)
+	m.ctrl.Call(m, "LogRuntimeInformation", info)
 }
 
 // LogRuntimeInformation indicates an expected call of LogRuntimeInformation.
-func (mr *MockRuntimeAPIMockRecorder) LogRuntimeInformation(runInfo interface{}) *gomock.Call {
+func (mr *MockRuntimeAPIMockRecorder) LogRuntimeInformation(info interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogRuntimeInformation", reflect.TypeOf((*MockRuntimeAPI)(nil).LogRuntimeInformation), runInfo)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogRuntimeInformation", reflect.TypeOf((*MockRuntimeAPI)(nil).LogRuntimeInformation), info)
 }


### PR DESCRIPTION
PR changes:
1) add ReleaseImageMachineOSConfig API - get the OS data (major/minor etc'), need by preflight
2) change ReleaseManifests API - no need to return version, not in use
3) refactor function, add common helper function getHeaderFromLayer