### PR TITLE
MGMT-9766: change Makefile manager target output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ helm-plugins/cm-getter: helm-plugins/cm-getter/cm-getter
 .PHONY: helm-plugins
 helm-plugins: helm-plugins/cm-getter
 
+.PHONY: manager
 manager:
 	go build -o manager main.go
 


### PR DESCRIPTION
Currently manager target in the Makefile produces manager executable, therefore changing the source code files does not trigger rebuilt.
This PR changes the output executable to be sro_manager