### PR TITLE
MGMT-9731: add helmer package API for preflight preprocessing

### DIFF
--- a/pkg/helmer/helmer_test.go
+++ b/pkg/helmer/helmer_test.go
@@ -134,3 +134,30 @@ var _ = Describe("helmer_Run", func() {
 		Expect(errors.Is(err, randomError)).To(BeTrue())
 	})
 })
+
+var _ = Describe("helmer_GetHelmOutput", func() {
+	const (
+		name      = "some-name"
+		namespace = "some-namespace"
+	)
+
+	It("good flow", func() {
+		ch := chart.Chart{
+			Files: []*chart.File{
+				{
+					Name: "crds/test.yml",
+					Data: nil,
+				},
+			},
+			Metadata: &chart.Metadata{
+				Name: name,
+				Type: "application",
+			},
+		}
+
+		h, err := newHelmerWithVersions(mockCreator, cli.New(), nil, nil, mockKubeClient)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = h.GetHelmOutput(context.TODO(), ch, nil, namespace)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
For the preflight code we need to preprocess the helm charts of a CR
to get all the resulting yamls, without actually loading them into the cluster.
This PR does the following
1) add an API that just does the helm preprocessing and returns a list of yaml
2) change Run API to use the shared code of the new API