### PR TITLE
MGMT-9763: add resource pkg API to support preflight validations

### DIFF
--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -296,7 +296,7 @@ metadata:
 		ns = append(ns, add...)
 	}
 
-	if err := r.Creator.CreateFromYAML(ctx, ns, false, wi.SpecialResource, wi.SpecialResource.Name, "", nil, "", ""); err != nil {
+	if err := r.ResourceAPI.CreateFromYAML(ctx, ns, false, wi.SpecialResource, wi.SpecialResource.Name, "", nil, "", ""); err != nil {
 		return err
 	}
 

--- a/controllers/specialresource.go
+++ b/controllers/specialresource.go
@@ -306,7 +306,7 @@ func (r *SpecialResourceReconciler) createSpecialResourceFrom(ctx context.Contex
 
 	log.Info("Creating SpecialResource", "name", ch.Files[idx].Name)
 
-	if err := r.Creator.CreateFromYAML(
+	if err := r.ResourceAPI.CreateFromYAML(
 		ctx,
 		ch.Files[idx].Data,
 		false,

--- a/controllers/specialresource_controller.go
+++ b/controllers/specialresource_controller.go
@@ -64,7 +64,7 @@ type SpecialResourceReconciler struct {
 	Cluster                cluster.Cluster
 	ClusterInfo            upgrade.ClusterInfo
 	ClusterOperatorManager state.ClusterOperatorManager
-	Creator                resource.Creator
+	ResourceAPI            resource.ResourceAPI
 	Filter                 filter.Filter
 	Finalizer              finalizers.SpecialResourceFinalizer
 	Helmer                 helmer.Helmer

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 	kernelAPI := kernel.NewKernelData()
 	proxyAPI := proxy.NewProxyAPI(kubeClient)
 
-	creator := resource.NewCreator(
+	resourceAPI := resource.NewResourceAPI(
 		kubeClient,
 		metricsClient,
 		pollActions,
@@ -128,7 +128,7 @@ func main() {
 	clusterInfoAPI := upgrade.NewClusterInfo(registry.NewRegistry(kubeClient), clusterAPI)
 	runtimeAPI := runtime.NewRuntimeAPI(kubeClient, clusterAPI, kernelAPI, clusterInfoAPI, proxyAPI)
 
-	helmerAPI, err := helmer.NewHelmer(creator, kubeClient)
+	helmerAPI, err := helmer.NewHelmer(resourceAPI, kubeClient)
 	if err != nil {
 		setupLog.Error(err, "Unable to setup helmer")
 		os.Exit(1)
@@ -137,7 +137,7 @@ func main() {
 	if err = (&controllers.SpecialResourceReconciler{Cluster: clusterAPI,
 		ClusterInfo:            clusterInfoAPI,
 		ClusterOperatorManager: state.NewClusterOperatorManager(kubeClient, "special-resource-operator"),
-		Creator:                creator,
+		ResourceAPI:            resourceAPI,
 		PollActions:            pollActions,
 		Filter:                 filter.NewFilter(lc, st, kernelAPI),
 		Finalizer:              finalizers.NewSpecialResourceFinalizer(kubeClient, pollActions),

--- a/pkg/helmer/helmer_test.go
+++ b/pkg/helmer/helmer_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 var (
-	ctrl           *gomock.Controller
-	mockCreator    *resource.MockCreator
-	mockKubeClient *clients.MockClientsInterface
+	ctrl            *gomock.Controller
+	mockResourceAPI *resource.MockResourceAPI
+	mockKubeClient  *clients.MockClientsInterface
 )
 
 func TestHelmer(t *testing.T) {
@@ -26,7 +26,7 @@ func TestHelmer(t *testing.T) {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		mockCreator = resource.NewMockCreator(ctrl)
+		mockResourceAPI = resource.NewMockResourceAPI(ctrl)
 		mockKubeClient = clients.NewMockClientsInterface(ctrl)
 	})
 
@@ -44,12 +44,12 @@ var _ = Describe("helmer_InstallCRDs", func() {
 	It("should return an error when a CRD cannot be created", func() {
 		randomError := errors.New("random error")
 
-		mockCreator.
+		mockResourceAPI.
 			EXPECT().
 			CreateFromYAML(context.TODO(), nil, false, owner, name, namespace, nil, "", "").
 			Return(randomError)
 
-		h, err := newHelmerWithVersions(mockCreator, cli.New(), nil, nil, mockKubeClient)
+		h, err := newHelmerWithVersions(mockResourceAPI, cli.New(), nil, nil, mockKubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		err = h.InstallCRDs(context.TODO(), nil, owner, name, namespace)
 		Expect(err).To(Equal(randomError))
@@ -75,11 +75,11 @@ abc
 def
 `)
 
-		mockCreator.
+		mockResourceAPI.
 			EXPECT().
 			CreateFromYAML(context.TODO(), manifests, false, owner, name, namespace, nil, "", "")
 
-		h, err := newHelmerWithVersions(mockCreator, cli.New(), nil, nil, mockKubeClient)
+		h, err := newHelmerWithVersions(mockResourceAPI, cli.New(), nil, nil, mockKubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		err = h.InstallCRDs(context.TODO(), crds, owner, name, namespace)
 		Expect(err).NotTo(HaveOccurred())
@@ -102,7 +102,7 @@ var _ = Describe("helmer_Run", func() {
 			},
 		}
 
-		h, err := newHelmerWithVersions(mockCreator, cli.New(), nil, nil, mockKubeClient)
+		h, err := newHelmerWithVersions(mockResourceAPI, cli.New(), nil, nil, mockKubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		err = h.Run(context.TODO(), ch, nil, owner, name, namespace, nil, "", "", false)
 		Expect(err).To(HaveOccurred())
@@ -124,11 +124,11 @@ var _ = Describe("helmer_Run", func() {
 
 		randomError := errors.New("random error")
 
-		mockCreator.
+		mockResourceAPI.
 			EXPECT().
 			CreateFromYAML(context.TODO(), gomock.Any(), false, owner, name, namespace, nil, "", "").
 			Return(randomError)
-		h, err := newHelmerWithVersions(mockCreator, cli.New(), nil, nil, mockKubeClient)
+		h, err := newHelmerWithVersions(mockResourceAPI, cli.New(), nil, nil, mockKubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		err = h.Run(context.TODO(), ch, nil, owner, name, namespace, nil, "", "", false)
 		Expect(errors.Is(err, randomError)).To(BeTrue())
@@ -155,7 +155,7 @@ var _ = Describe("helmer_GetHelmOutput", func() {
 			},
 		}
 
-		h, err := newHelmerWithVersions(mockCreator, cli.New(), nil, nil, mockKubeClient)
+		h, err := newHelmerWithVersions(mockResourceAPI, cli.New(), nil, nil, mockKubeClient)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = h.GetHelmOutput(context.TODO(), ch, nil, namespace)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/resource/mock_resource_api.go
+++ b/pkg/resource/mock_resource_api.go
@@ -10,33 +10,34 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-// MockCreator is a mock of Creator interface.
-type MockCreator struct {
+// MockResourceAPI is a mock of ResourceAPI interface.
+type MockResourceAPI struct {
 	ctrl     *gomock.Controller
-	recorder *MockCreatorMockRecorder
+	recorder *MockResourceAPIMockRecorder
 }
 
-// MockCreatorMockRecorder is the mock recorder for MockCreator.
-type MockCreatorMockRecorder struct {
-	mock *MockCreator
+// MockResourceAPIMockRecorder is the mock recorder for MockResourceAPI.
+type MockResourceAPIMockRecorder struct {
+	mock *MockResourceAPI
 }
 
-// NewMockCreator creates a new mock instance.
-func NewMockCreator(ctrl *gomock.Controller) *MockCreator {
-	mock := &MockCreator{ctrl: ctrl}
-	mock.recorder = &MockCreatorMockRecorder{mock}
+// NewMockResourceAPI creates a new mock instance.
+func NewMockResourceAPI(ctrl *gomock.Controller) *MockResourceAPI {
+	mock := &MockResourceAPI{ctrl: ctrl}
+	mock.recorder = &MockResourceAPIMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockCreator) EXPECT() *MockCreatorMockRecorder {
+func (m *MockResourceAPI) EXPECT() *MockResourceAPIMockRecorder {
 	return m.recorder
 }
 
 // CreateFromYAML mocks base method.
-func (m *MockCreator) CreateFromYAML(arg0 context.Context, arg1 []byte, arg2 bool, arg3 v1.Object, arg4, arg5 string, arg6 map[string]string, arg7, arg8 string) error {
+func (m *MockResourceAPI) CreateFromYAML(arg0 context.Context, arg1 []byte, arg2 bool, arg3 v1.Object, arg4, arg5 string, arg6 map[string]string, arg7, arg8 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateFromYAML", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	ret0, _ := ret[0].(error)
@@ -44,7 +45,22 @@ func (m *MockCreator) CreateFromYAML(arg0 context.Context, arg1 []byte, arg2 boo
 }
 
 // CreateFromYAML indicates an expected call of CreateFromYAML.
-func (mr *MockCreatorMockRecorder) CreateFromYAML(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
+func (mr *MockResourceAPIMockRecorder) CreateFromYAML(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFromYAML", reflect.TypeOf((*MockCreator)(nil).CreateFromYAML), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFromYAML", reflect.TypeOf((*MockResourceAPI)(nil).CreateFromYAML), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+}
+
+// GetObjectsFromYAML mocks base method.
+func (m *MockResourceAPI) GetObjectsFromYAML(arg0 []byte) (*unstructured.UnstructuredList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetObjectsFromYAML", arg0)
+	ret0, _ := ret[0].(*unstructured.UnstructuredList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetObjectsFromYAML indicates an expected call of GetObjectsFromYAML.
+func (mr *MockResourceAPIMockRecorder) GetObjectsFromYAML(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectsFromYAML", reflect.TypeOf((*MockResourceAPI)(nil).GetObjectsFromYAML), arg0)
 }


### PR DESCRIPTION
The changes in this PR:
1) add API to get a list of Objects from helm YAMLs
2) rename Creator interface to ResourceAPI, and update the code accordingly