### PR TITLE
Adding CI artifacts.

### DIFF
--- a/ci/podman.yaml
+++ b/ci/podman.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: podman
+spec:
+  containers:
+  - name: podman
+    image: registry.redhat.io/rhel8/podman:latest
+    command:
+    - /usr/sbin/init
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: pull-secret
+      mountPath: "/run/user/0/containers/"
+      readOnly: true
+  volumes:
+  - name: pull-secret
+    secret:
+      secretName: pull-secret


### PR DESCRIPTION
We will deploy a podman container in the CI ephemeral cluster in order to
build SRO in a disconnected env.

This pod has to mount the pull-secret secret of the cluster, therefore, it
can't be initiated via cli as there is no option to mount a volume
on the pod's creation via cli and k8s doesn't supporting patching volumes
on running pods.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>