### PR TITLE
Fixing the default IMG for SRO.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ IMAGE_TAG_BASE ?= quay.io/openshift-psap/special-resource-operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/openshift-psap/special-resource-operator:$(TAG)
+IMG ?= quay.io/openshift/origin-special-resource-rhel8-operator:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.


### PR DESCRIPTION
It is currently set to the u/s image on quay.io/openshift-psap org
according to our GH action that does that u/s.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

The new image is build by OCP Prow on each push https://github.com/openshift/release/blob/a88469e7c9dbe0c5a7443ed54989ee5f59bc9a0a/core-services/image-mirroring/openshift/mapping_origin_4_11#L267