### PR TITLE
Remove dagrayvid from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,11 @@
 approvers:
   - bthurber
-  - dagrayvid
   - pacevedom
   - qbarrand
   - ybettan
   - yevgeny-shnaidman
 reviewers:
   - bthurber
-  - dagrayvid
   - pacevedom
   - pmtk
   - qbarrand


### PR DESCRIPTION
Now that the SRO team has fully ramped up on ownership of SRO, I think I can be removed from the OWNERS. I am no longer actively involved in the project and probably shouldn't be selected as a reviewer.

I am always happy to consult on this project when specific issues or questions come up where I can help!