### PR TITLE
Removing debug printouts in the cm-getter plugin

### DIFF
--- a/pkg/helmer/helmer.go
+++ b/pkg/helmer/helmer.go
@@ -46,7 +46,6 @@ func defaultSettings() (*cli.EnvSettings, error) {
 	s.RepositoryConfig = filepath.Join(cacheDir, "special-resource-operator/helm/repositories/config.yaml")
 	s.RepositoryCache = filepath.Join(cacheDir, "special-resource-operator/helm/cache")
 	s.RegistryConfig = filepath.Join(cacheDir, "special-resource-operator/helm/registry.json")
-	s.Debug = true
 	s.MaxHistory = 10
 
 	return s, nil


### PR DESCRIPTION
Debug printouts are dependent on the HELM_DEBUG env variable
which can be set either via enviroment, or via helm enviroment
struct Debug flag configuration.