### PR TITLE
Enhancing returned errors for pkg/lifecycle.

### DIFF
--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -1,0 +1,7 @@
+package utils
+
+import "fmt"
+
+func WarnString(str string) string {
+	return fmt.Sprintf("WARNING: %s", str)
+}


### PR DESCRIPTION
This is part of the logging enhancement effort which says that:
  * all errors should be wrapped with its context
  * error logging should only be done at the reconciliation loop level
  * info and warning logs can be everywhere in the code

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>