### PR TITLE
MGMT-10184: Remove special-resource-lifecycle configmap usage

### DIFF
--- a/manifests/0014_configmap_special-resource-lifecycle.yaml
+++ b/manifests/0014_configmap_special-resource-lifecycle.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-data: null
-kind: ConfigMap
-metadata:
-  name: special-resource-lifecycle
-  namespace: openshift-special-resource-operator

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -1,7 +1,6 @@
 package filter
 
 import (
-	"context"
 	"io/ioutil"
 	"testing"
 
@@ -274,7 +273,6 @@ var _ = Describe("Predicate", func() {
 				"Object has changed and it's a SRO owned DaemonSet",
 				func() {
 					mockKernel.EXPECT().IsObjectAffine(gomock.Any()).Return(true)
-					mockLifecycle.EXPECT().UpdateDaemonSetPods(context.TODO(), gomock.Any())
 				},
 				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
@@ -331,7 +329,6 @@ var _ = Describe("Predicate", func() {
 				"Object is a SRO owned & kernel affine DaemonSet",
 				func() {
 					mockKernel.EXPECT().IsObjectAffine(gomock.Any()).Return(true)
-					mockLifecycle.EXPECT().UpdateDaemonSetPods(context.TODO(), gomock.Any())
 				},
 				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -2,7 +2,6 @@ package lifecycle_test
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -15,7 +14,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -134,65 +132,5 @@ var _ = Describe("GetPodFromDeployment", func() {
 			GetPodFromDeployment(context.Background(), types.NamespacedName{Namespace: namespace, Name: name})
 
 		Expect(pl.Items).To(HaveLen(nPod))
-	})
-})
-
-var _ = Describe("UpdateDaemonSetPods", func() {
-	const namespaceEnvVar = "OPERATOR_NAMESPACE"
-
-	AfterEach(func() {
-		err := os.Unsetenv(namespaceEnvVar)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should update the ConfigMap", func() {
-		err := os.Setenv(namespaceEnvVar, namespace)
-		Expect(err).NotTo(HaveOccurred())
-
-		nsn := types.NamespacedName{
-			Namespace: namespace,
-			Name:      name,
-		}
-
-		cmNsn := types.NamespacedName{
-			Namespace: namespace,
-			Name:      "special-resource-lifecycle",
-		}
-
-		gomock.InOrder(
-			mockClient.EXPECT().
-				Get(context.Background(), nsn, &appsv1.DaemonSet{}).
-				Do(func(_ context.Context, key types.NamespacedName, ds *appsv1.DaemonSet) {
-					ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
-					ds.SetNamespace(key.Namespace)
-				}),
-			mockClient.EXPECT().
-				List(context.Background(), &v1.PodList{}, optNs, optLabels).
-				Do(func(_ context.Context, pl *v1.PodList, _, _ client.ListOption) {
-					pl.Items = []v1.Pod{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "pod1",
-								Namespace: namespace,
-							},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "pod2",
-								Namespace: namespace,
-							},
-						},
-					}
-				}),
-			mockStorage.EXPECT().UpdateConfigMapEntry(context.Background(), "39005a809548c688", "*v1.Pod", cmNsn),
-			mockStorage.EXPECT().UpdateConfigMapEntry(context.Background(), "39005d809548cba1", "*v1.Pod", cmNsn),
-		)
-
-		obj := unstructured.Unstructured{}
-		obj.SetNamespace(namespace)
-		obj.SetName(name)
-
-		err = lifecycle.New(mockClient, mockStorage).UpdateDaemonSetPods(context.Background(), &obj)
-		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/pkg/lifecycle/mock_lifecycle_api.go
+++ b/pkg/lifecycle/mock_lifecycle_api.go
@@ -11,7 +11,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	types "k8s.io/apimachinery/pkg/types"
-	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // MockLifecycle is a mock of Lifecycle interface.
@@ -63,18 +62,4 @@ func (m *MockLifecycle) GetPodFromDeployment(arg0 context.Context, arg1 types.Na
 func (mr *MockLifecycleMockRecorder) GetPodFromDeployment(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodFromDeployment", reflect.TypeOf((*MockLifecycle)(nil).GetPodFromDeployment), arg0, arg1)
-}
-
-// UpdateDaemonSetPods mocks base method.
-func (m *MockLifecycle) UpdateDaemonSetPods(arg0 context.Context, arg1 client.Object) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateDaemonSetPods", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateDaemonSetPods indicates an expected call of UpdateDaemonSetPods.
-func (mr *MockLifecycleMockRecorder) UpdateDaemonSetPods(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDaemonSetPods", reflect.TypeOf((*MockLifecycle)(nil).UpdateDaemonSetPods), arg0, arg1)
 }


### PR DESCRIPTION
special-resource-lifecycle configmap is used by SRO to monitor the pods of the Daemonsets.
The main use is for DaemonSets with updateStrategy set "onDelete".
With "onDelete" strategy, upon DS update no new pods are created until the old one are deleted externally
(by user or some other code).
In ForDaemonSet function in poll package, we have 3 stages of polling:
1) Check that DS exists
2) in case of onDelete, check DS pods are not present in configmap (meaning they were deleted
3) wait for DS desired number of pods to equal numberAvailble

This PR will remove the configmap, and now will check that all the pods were
deleted by checking that DS generation label and pods generation template label are equal
(meaning that only the new pods are running)