### PR TITLE
MGMT-10211: Remove platform-dependent code from controllers for downs…

### DIFF
--- a/controllers/specialresource_controller.go
+++ b/controllers/specialresource_controller.go
@@ -176,54 +176,27 @@ func (r *SpecialResourceReconciler) getSpecialResources(ctx context.Context, req
 
 // SetupWithManager main initalization for manager
 func (r *SpecialResourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	platform, err := r.KubeClient.GetPlatform()
-	if err != nil {
-		return err
-	}
-
-	if platform == "OCP" {
-		return ctrl.NewControllerManagedBy(mgr).
-			Named("specialresource").
-			For(&srov1beta1.SpecialResource{}).
-			Owns(&v1.Pod{}).
-			Owns(&appsv1.DaemonSet{}).
-			Owns(&appsv1.Deployment{}).
-			Owns(&storagev1.CSIDriver{}).
-			Owns(&imagev1.ImageStream{}).
-			Owns(&buildv1.BuildConfig{}).
-			Owns(&v1.ConfigMap{}).
-			Owns(&v1.ServiceAccount{}).
-			Owns(&rbacv1.Role{}).
-			Owns(&rbacv1.RoleBinding{}).
-			Owns(&rbacv1.ClusterRole{}).
-			Owns(&rbacv1.ClusterRoleBinding{}).
-			Owns(&secv1.SecurityContextConstraints{}).
-			Owns(&v1.Secret{}).
-			WithOptions(controller.Options{
-				MaxConcurrentReconciles: 1,
-				RateLimiter:             workqueue.NewItemExponentialFailureRateLimiter(minDelaySR, maxDelaySR),
-			}).
-			WithEventFilter(r.Filter.GetPredicates()).
-			Complete(r)
-	} else {
-		return ctrl.NewControllerManagedBy(mgr).
-			Named("specialresource").
-			For(&srov1beta1.SpecialResource{}).
-			Owns(&v1.Pod{}).
-			Owns(&appsv1.DaemonSet{}).
-			Owns(&appsv1.Deployment{}).
-			Owns(&storagev1.CSIDriver{}).
-			Owns(&v1.ConfigMap{}).
-			Owns(&v1.ServiceAccount{}).
-			Owns(&rbacv1.Role{}).
-			Owns(&rbacv1.RoleBinding{}).
-			Owns(&rbacv1.ClusterRole{}).
-			Owns(&rbacv1.ClusterRoleBinding{}).
-			Owns(&v1.Secret{}).
-			WithOptions(controller.Options{
-				MaxConcurrentReconciles: 1,
-			}).
-			WithEventFilter(r.Filter.GetPredicates()).
-			Complete(r)
-	}
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("specialresource").
+		For(&srov1beta1.SpecialResource{}).
+		Owns(&v1.Pod{}).
+		Owns(&appsv1.DaemonSet{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&storagev1.CSIDriver{}).
+		Owns(&imagev1.ImageStream{}).
+		Owns(&buildv1.BuildConfig{}).
+		Owns(&v1.ConfigMap{}).
+		Owns(&v1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
+		Owns(&secv1.SecurityContextConstraints{}).
+		Owns(&v1.Secret{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+			RateLimiter:             workqueue.NewItemExponentialFailureRateLimiter(minDelaySR, maxDelaySR),
+		}).
+		WithEventFilter(r.Filter.GetPredicates()).
+		Complete(r)
 }

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	buildv1 "github.com/openshift/api/build/v1"
 	configv1 "github.com/openshift/api/config/v1"
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -53,7 +52,6 @@ type ClientsInterface interface {
 	CreateOrUpdate(ctx context.Context, obj client.Object, fn controllerutil.MutateFn) (controllerutil.OperationResult, error)
 	HasResource(resource schema.GroupVersionResource) (bool, error)
 	GetNodesByLabels(ctx context.Context, matchingLabels map[string]string) (*v1.NodeList, error)
-	GetPlatform() (string, error)
 }
 
 type k8sClients struct {
@@ -181,18 +179,6 @@ func (k *k8sClients) HasResource(resource schema.GroupVersionResource) (bool, er
 		}
 	}
 	return false, nil
-}
-
-func (k *k8sClients) GetPlatform() (string, error) {
-	clusterIsOCP, err := k.HasResource(buildv1.SchemeGroupVersion.WithResource("buildconfigs"))
-	if err != nil {
-		return "", err
-	}
-	if clusterIsOCP {
-		return "OCP", nil
-	} else {
-		return "K8S", nil
-	}
 }
 
 func (k *k8sClients) GetNodesByLabels(ctx context.Context, matchingLabels map[string]string) (*v1.NodeList, error) {

--- a/pkg/clients/mock_clients_api.go
+++ b/pkg/clients/mock_clients_api.go
@@ -188,21 +188,6 @@ func (mr *MockClientsInterfaceMockRecorder) GetNodesByLabels(ctx, matchingLabels
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodesByLabels", reflect.TypeOf((*MockClientsInterface)(nil).GetNodesByLabels), ctx, matchingLabels)
 }
 
-// GetPlatform mocks base method.
-func (m *MockClientsInterface) GetPlatform() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPlatform")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPlatform indicates an expected call of GetPlatform.
-func (mr *MockClientsInterfaceMockRecorder) GetPlatform() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlatform", reflect.TypeOf((*MockClientsInterface)(nil).GetPlatform))
-}
-
 // GetPodLogs mocks base method.
 func (m *MockClientsInterface) GetPodLogs(namespace, podName string, podLogOpts *v10.PodLogOptions) *rest.Request {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
…tream

Since downstream is always running on OCP,
no need to check which platfrom SRO is running on in its controllers