### PR TITLE
Bug 2070172: Use the SpecialResource's name as Helm release

### DIFF
--- a/pkg/helmer/helmer_test.go
+++ b/pkg/helmer/helmer_test.go
@@ -158,7 +158,7 @@ var _ = Describe("helmer_GetHelmOutput", func() {
 
 		h, err := newHelmerWithVersions(mockResourceAPI, cli.New(), nil, nil, mockKubeClient)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = h.GetHelmOutput(context.TODO(), ch, nil, namespace)
+		_, err = h.GetHelmOutput(context.TODO(), ch, nil, name, namespace)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/pkg/helmer/mock_helmer_api.go
+++ b/pkg/helmer/mock_helmer_api.go
@@ -38,18 +38,18 @@ func (m *MockHelmer) EXPECT() *MockHelmerMockRecorder {
 }
 
 // GetHelmOutput mocks base method.
-func (m *MockHelmer) GetHelmOutput(arg0 context.Context, arg1 chart.Chart, arg2 map[string]interface{}, arg3 string) (string, error) {
+func (m *MockHelmer) GetHelmOutput(arg0 context.Context, arg1 chart.Chart, arg2 map[string]interface{}, arg3, arg4 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHelmOutput", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetHelmOutput", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetHelmOutput indicates an expected call of GetHelmOutput.
-func (mr *MockHelmerMockRecorder) GetHelmOutput(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockHelmerMockRecorder) GetHelmOutput(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHelmOutput", reflect.TypeOf((*MockHelmer)(nil).GetHelmOutput), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHelmOutput", reflect.TypeOf((*MockHelmer)(nil).GetHelmOutput), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Load mocks base method.

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -77,7 +77,7 @@ func (p *preflight) PreflightUpgradeCheck(ctx context.Context,
 		return false, fmt.Sprintf("Failed to load helm chart for CR %s", sr.Name), err
 	}
 
-	yamlsList, err := p.processFullChartTemplates(ctx, chart, sr.Spec.Set, runInfo, sr.Namespace, runInfo.KernelFullVersion)
+	yamlsList, err := p.processFullChartTemplates(ctx, chart, sr.Spec.Set, runInfo, sr.Name, sr.Namespace, runInfo.KernelFullVersion)
 	if err != nil {
 		err = fmt.Errorf("failed to processFullChartTemplates in PreflightUpgradeCheck, CR name %s: %w", sr.Name, err)
 		return false, fmt.Sprintf("Failed to process full chart for CR %s", sr.Name), err
@@ -89,6 +89,7 @@ func (p *preflight) processFullChartTemplates(ctx context.Context,
 	chart *helmchart.Chart,
 	values unstructured.Unstructured,
 	runInfo *runtime.RuntimeInformation,
+	name string,
 	namespace string,
 	upgradeKernelVersion string) (string, error) {
 
@@ -120,7 +121,7 @@ func (p *preflight) processFullChartTemplates(ctx context.Context,
 		return "", fmt.Errorf("failed to coalesce runInfo into chart in processFullChartTemplates, chart name %s: %w", fullChart.Name(), err)
 	}
 
-	return p.helmerAPI.GetHelmOutput(ctx, fullChart, fullChart.Values, namespace)
+	return p.helmerAPI.GetHelmOutput(ctx, fullChart, fullChart.Values, name, namespace)
 }
 
 func (p *preflight) handleYAMLsCheck(ctx context.Context, yamlsList string, upgradeKernelVersion string) (bool, string, error) {


### PR DESCRIPTION
This PR makes `pkg/helmer` code use the SpecialResource's name as the Helm release name. This avoids collisions when two SpecialResources are targeting the same chart.