### PR TITLE
Bug 2089719: Add arch to kernel versions

### DIFF
--- a/controllers/specialresourcemodule_controller.go
+++ b/controllers/specialresourcemodule_controller.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -307,6 +308,18 @@ func (r *SpecialResourceModuleReconciler) getVersionInfoFromImage(ctx context.Co
 	dtkEntry, err := r.Registry.ExtractToolkitRelease(dtkLastLayer)
 	if err != nil {
 		return ocpVersionInfo{}, fmt.Errorf("failed to extract toolkit release from layer '%s': %w", dtkLastLayer, err)
+	}
+
+	runningArch := runtime.GOARCH
+	switch runningArch {
+	case "amd64":
+		runningArch = "x86_64"
+	case "arm64":
+		runningArch = "aarch64"
+	}
+	if !strings.Contains(dtkEntry.KernelFullVersion, runningArch) {
+		dtkEntry.KernelFullVersion = dtkEntry.KernelFullVersion + "." + runningArch
+		dtkEntry.RTKernelFullVersion = dtkEntry.RTKernelFullVersion + "." + runningArch
 	}
 
 	return ocpVersionInfo{


### PR DESCRIPTION
Solves [BZ 2089719](https://bugzilla.redhat.com/show_bug.cgi?id=2089719) by adding the arch when its missing from the release info in DTK (happens in older versions). This renders builds not working when using the `kernelFullVersion` or `rKernelFullVersion` variables in recipes.