### PR TITLE
Bug 2092867: Add chart name to ACM simple kmod and ACM ICE driver

### DIFF
--- a/charts/example/acm-ice-0.0.1/acm-ice.yaml
+++ b/charts/example/acm-ice-0.0.1/acm-ice.yaml
@@ -8,7 +8,7 @@ spec:
     name: acm-ice
     version: 0.0.1
     repository:
-      name: chart
+      name: acm-ice
       url: cm://acm-ice/acm-ice-chart
   set:
     kind: Values

--- a/charts/example/acm-simple-kmod-0.0.1/acm-simple-kmod.yaml
+++ b/charts/example/acm-simple-kmod-0.0.1/acm-simple-kmod.yaml
@@ -8,7 +8,7 @@ spec:
     name: acm-simple-kmod
     version: 0.0.1
     repository:
-      name: chart
+      name: acm-simple-kmod
       url: cm://acm-simple-kmod/acm-simple-kmod
   set:
     kind: Values


### PR DESCRIPTION
Having the same chart name in the SpecialResource/SpecialResourceModule
CR triggers 0 byte size files in helm internal cache, not being able
to read the helm recipe's contents and failing to reconcile.