### PR TITLE
Bug 2088324: Some manifests still have KVC references

### DIFF
--- a/bundle/4.11/manifests/openshift-special-resource-operator.v4.11.0.clusterserviceversion.yaml
+++ b/bundle/4.11/manifests/openshift-special-resource-operator.v4.11.0.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
               "source": {
                 "git": {
                   "ref": "master",
-                  "uri": "https://github.com/openshift-psap/kvc-simple-kmod.git"
+                  "uri": "https://github.com/openshift-psap/simple-kmod.git"
                 }
               }
             },

--- a/charts/example/acm-simple-kmod-0.0.1/acm-simple-kmod.yaml
+++ b/charts/example/acm-simple-kmod-0.0.1/acm-simple-kmod.yaml
@@ -19,7 +19,7 @@ spec:
     registry: quay.io/pacevedo
     git:
       ref: master
-      uri: https://github.com/openshift-psap/kvc-simple-kmod.git
+      uri: https://github.com/openshift-psap/simple-kmod.git
   watch:
     - path: "$.metadata.labels.openshiftVersion"
       apiVersion: cluster.open-cluster-management.io/v1

--- a/config/manifests/bases/openshift-special-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-special-resource-operator.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '["apiVersion":"sro.openshift.io/v1beta1","kind":"SpecialResource","metadata":{"name":"simple-kmod"},"spec":{"namespace":"simple-kmod","configuration":[{"name":"KMOD_NAMES","value":["simple-kmod","simple-procfs-kmod"]}],"driverContainer":{"source":{"git":{"ref":"master","uri":"https://github.com/openshift-psap/kvc-simple-kmod.git"}},"buildArgs":[{"name":"KVER","value":"{{.Values.kernelFullVersion}}"},{"name":"KMODVER","value":"SRO"}]},"dependsOn":[{"name":"driver-container-base","imageReference":"true"}]}}]'
+    alm-examples: '["apiVersion":"sro.openshift.io/v1beta1","kind":"SpecialResource","metadata":{"name":"simple-kmod"},"spec":{"namespace":"simple-kmod","configuration":[{"name":"KMOD_NAMES","value":["simple-kmod","simple-procfs-kmod"]}],"driverContainer":{"source":{"git":{"ref":"master","uri":"https://github.com/openshift-psap/simple-kmod.git"}},"buildArgs":[{"name":"KVER","value":"{{.Values.kernelFullVersion}}"},{"name":"KMODVER","value":"SRO"}]},"dependsOn":[{"name":"driver-container-base","imageReference":"true"}]}}]'
     capabilities: Basic Install
     categories: AI/Machine Learning, OpenShift Optional, Storage
     description: The special resource operator is an orchestrator for resources in

--- a/config/samples/sro_v1beta1_specialresource.yaml
+++ b/config/samples/sro_v1beta1_specialresource.yaml
@@ -21,4 +21,4 @@ spec:
     source:
       git:
         ref: "master"
-        uri: "https://github.com/openshift-psap/kvc-simple-kmod.git"
+        uri: "https://github.com/openshift-psap/simple-kmod.git"

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -75,7 +75,7 @@ spec:
     source:
       git:
         ref: "master"
-        uri: "https://github.com/openshift-psap/kvc-simple-kmod.git"
+        uri: "https://github.com/openshift-psap/simple-kmod.git"
 ```
 
 SRO will print each complete state the corresponding values.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -23,7 +23,7 @@ spec:
     version: 0.0.1
     repository:
       name: example
-      url: file:///charts/example
+      url: cm://namespace/example-chart
   set:
     kind: Values
     apiVersion: sro.openshift.io/v1beta1
@@ -35,7 +35,7 @@ spec:
     source:
       git:
         ref: "master"
-        uri: "https://github.com/openshift-psap/kvc-simple-kmod.git"
+        uri: "https://github.com/openshift-psap/simple-kmod.git"
 ```
 
 SRO keeps an internal Helm repository of all packaged helm charts, and they are
@@ -106,16 +106,16 @@ buildArgs:
 - name: KMODVER
   value: SRO
 clusterUpgradeInfo:
-  4.18.0-305.3.1.el8_4.x86_64:
-    clusterVersion: "4.8"
+  4.18.0-305.45.1.el8_4.x86_64:
+    clusterVersion: "4.10"
     driverToolkit:
       imageURL: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d07d95029663561dc58560751936dc9569bd77a397206e80fb5ab8778a56d920
-      kernelFullVersion: 4.18.0-305.3.1.el8_4.x86_64
+      kernelFullVersion: 4.18.0-305.45.1.el8_4.x86_64
       oSVersion: "8.4"
-      rTKernelFullVersion: 4.18.0-305.3.1.rt7.75.el8_4.x86_64
+      rTKernelFullVersion: 4.18.0-305.45.1.rt7.75.el8_4.x86_64
     oSVersion: "8.4"
-clusterVersion: 4.8.0-fc.8
-clusterVersionMajorMinor: "4.8"
+clusterVersion: 4.10.0-fc.8
+clusterVersionMajorMinor: "4.10"
 driverToolkitImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d07d95029663561dc58560751936dc9569bd77a397206e80fb5ab8778a56d920
 groupName:
   csiDriver: csi-driver
@@ -126,7 +126,7 @@ groupName:
   driverBuild: driver-build
   driverContainer: driver-container
   runtimeEnablement: runtime-enablement
-kernelFullVersion: 4.18.0-305.3.1.el8_4.x86_64
+kernelFullVersion: 4.18.0-305.45.1.el8_4.x86_64
 kernelPatchVersion: 4.18.0-305
 
 kmodNames:
@@ -163,7 +163,7 @@ specialresource:
         keyFile: ""
         name: example
         password: ""
-        url: file:///charts/example
+        url: cm:///simple-kmod/simple-kmod-chart
         username: ""
       tags: []
       version: 0.0.1
@@ -173,7 +173,7 @@ specialresource:
       source:
         git:
           ref: master
-          uri: https://github.com/openshift-psap/kvc-simple-kmod.git
+          uri: https://github.com/openshift-psap/simple-kmod.git
     forceUpgrade: false
     namespace: simple-kmod
     set:


### PR DESCRIPTION
Manifests from bundle and example in charts still refer to kvc-simple-kmod which leads to errors as[ kvc-simple-kmod repo](https://github.com/openshift-psap/kvc-simple-kmod) is no longer used by SRO in favor of [simple-kmod](https://github.com/openshift-psap/simple-kmod) which does not have [KVC](https://github.com/kmods-via-containers/kmods-via-containers) dependencies.
