### PR TITLE
Bug 2093357: hub and spokes: add OCP version retrieval and fix ICE driver

### DIFF
--- a/charts/example/acm-ice-0.0.1/templates/0001-buildconfig.yaml
+++ b/charts/example/acm-ice-0.0.1/templates/0001-buildconfig.yaml
@@ -33,8 +33,8 @@ apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   labels:
-    app: {{ printf "%s-%s" .Values.specialResourceModule.metadata.name .Values.kernelFullVersion | replace "." "-" | replace "_" "-" | trunc 63 }}
-  name: {{ printf "%s-%s" .Values.specialResourceModule.metadata.name .Values.kernelFullVersion | replace "." "-" | replace "_" "-" | trunc 63 }}
+    app: {{ printf "%s-%s" .Values.specialResourceModule.metadata.name .Values.openShiftVersion | replace "." "-" | replace "_" "-" | trunc 63 }}
+  name: {{ printf "%s-%s" .Values.specialResourceModule.metadata.name .Values.openShiftVersion | replace "." "-" | replace "_" "-" | trunc 63 }}
   annotations:
     specialresource.openshift.io/wait: "true"
 spec:

--- a/charts/example/acm-ice-0.0.1/templates/0002-policy.yaml
+++ b/charts/example/acm-ice-0.0.1/templates/0002-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
- name: policy-{{.Values.specialResourceModule.metadata.name}}-mc
+ name: {{ printf "%s-%s" .Values.specialResourceModule.metadata.name .Values.openShiftVersion | replace "." "-" | replace "_" "-" | trunc 63 }}
  annotations:
    policy.open-cluster-management.io/categories: CM Configuration Management
    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
@@ -14,7 +14,7 @@ spec:
        apiVersion: policy.open-cluster-management.io/v1
        kind: ConfigurationPolicy
        metadata:
-         name: policy-{{.Values.specialResourceModule.metadata.name}}-mc
+         name: {{ printf "%s-%s" .Values.specialResourceModule.metadata.name .Values.openShiftVersion | replace "." "-" | replace "_" "-" | trunc 63 }}
        spec:
          remediationAction: enforce
          severity: low
@@ -39,7 +39,7 @@ spec:
                    storage:
                      files:
                        - contents:
-                           source: 'data:text/plain;charset=us-ascii;base64,IyEvYmluL2Jhc2gKc2V0IC1ldQoKQUNUSU9OPSQxOyBzaGlmdApJTUFHRT0kMTsgc2hpZnQKS0VSTkVMPWB1bmFtZSAtcmAKCnBvZG1hbiBwdWxsIC0tYXV0aGZpbGUgL3Zhci9saWIva3ViZWxldC9jb25maWcuanNvbiAke0lNQUdFfToke0tFUk5FTH0gMj4mMQoKbG9hZF9rbW9kcygpIHsKCiAgICBwb2RtYW4gcnVuIC1pIC0tcHJpdmlsZWdlZCAtdiAvbGliL21vZHVsZXMvJHtLRVJORUx9L2tlcm5lbC9kcml2ZXJzLzovbGliL21vZHVsZXMvJHtLRVJORUx9L2tlcm5lbC9kcml2ZXJzLyAke0lNQUdFfToke0tFUk5FTH0gbG9hZC5zaAp9CnVubG9hZF9rbW9kcygpIHsKICAgIHBvZG1hbiBydW4gLWkgLS1wcml2aWxlZ2VkIC12IC9saWIvbW9kdWxlcy8ke0tFUk5FTH0va2VybmVsL2RyaXZlcnMvOi9saWIvbW9kdWxlcy8ke0tFUk5FTH0va2VybmVsL2RyaXZlcnMvICR7SU1BR0V9OiR7S0VSTkVMfSB1bmxvYWQuc2gKfQoKY2FzZSAiJHtBQ1RJT059IiBpbgogICAgbG9hZCkKICAgICAgICBsb2FkX2ttb2RzCiAgICA7OwogICAgdW5sb2FkKQogICAgICAgIHVubG9hZF9rbW9kcwogICAgOzsKICAgICopCiAgICAgICAgZWNobyAiVW5rbm93biBjb21tYW5kLiBFeGl0aW5nLiIKICAgICAgICBlY2hvICJVc2FnZToiCiAgICAgICAgZWNobyAiIgogICAgICAgIGVjaG8gImxvYWQgICAgICAgIExvYWQga2VybmVsIG1vZHVsZShzKSIKICAgICAgICBlY2hvICJ1bmxvYWQgICAgICBVbmxvYWQga2VybmVsIG1vZHVsZShzKSIKICAgICAgICBleGl0IDEKZXNhYwo='
+                           source: 'data:text/plain;charset=us-ascii;base64,IyEvYmluL2Jhc2gKc2V0IC1ldQoKQUNUSU9OPSQxOyBzaGlmdApJTUFHRT0kMTsgc2hpZnQKS0VSTkVMPSQxOyBzaGlmdAoKcG9kbWFuIHB1bGwgLS1hdXRoZmlsZSAvdmFyL2xpYi9rdWJlbGV0L2NvbmZpZy5qc29uICR7SU1BR0V9OiR7S0VSTkVMfSAyPiYxCgpsb2FkX2ttb2RzKCkgewogICAgcG9kbWFuIHJ1biAtaSAtLXByaXZpbGVnZWQgLXYgL2xpYi9tb2R1bGVzLyR7S0VSTkVMfS9rZXJuZWwvZHJpdmVycy86L2xpYi9tb2R1bGVzLyR7S0VSTkVMfS9rZXJuZWwvZHJpdmVycy8gJHtJTUFHRX06JHtLRVJORUx9IGxvYWQuc2gKfQp1bmxvYWRfa21vZHMoKSB7CiAgICBwb2RtYW4gcnVuIC1pIC0tcHJpdmlsZWdlZCAtdiAvbGliL21vZHVsZXMvJHtLRVJORUx9L2tlcm5lbC9kcml2ZXJzLzovbGliL21vZHVsZXMvJHtLRVJORUx9L2tlcm5lbC9kcml2ZXJzLyAke0lNQUdFfToke0tFUk5FTH0gdW5sb2FkLnNoCn0KCmNhc2UgIiR7QUNUSU9OfSIgaW4KICAgIGxvYWQpCiAgICAgICAgbG9hZF9rbW9kcwogICAgOzsKICAgIHVubG9hZCkKICAgICAgICB1bmxvYWRfa21vZHMKICAgIDs7CiAgICAqKQogICAgICAgIGVjaG8gIlVua25vd24gY29tbWFuZC4gRXhpdGluZy4iCiAgICAgICAgZWNobyAiVXNhZ2U6IgogICAgICAgIGVjaG8gIiIKICAgICAgICBlY2hvICJsb2FkICAgICAgICBMb2FkIGtlcm5lbCBtb2R1bGUocykiCiAgICAgICAgZWNobyAidW5sb2FkICAgICAgVW5sb2FkIGtlcm5lbCBtb2R1bGUocykiCiAgICAgICAgZXhpdCAxCmVzYWM='
                          filesystem: root
                          mode: 493
                          path: /usr/local/bin/{{.Values.specialResourceModule.metadata.name}}
@@ -60,8 +60,8 @@ spec:
                          Type=oneshot
                          RemainAfterExit=true
                          # Use bash to workaround https://github.com/coreos/rpm-ostree/issues/1936
-                         ExecStart=/usr/bin/bash -c "while ! /usr/local/bin/{{.Values.specialResourceModule.metadata.name}} load {{.Values.registry}}/{{.Values.specialResourceModule.metadata.name}}-{{.Values.groupName.driverContainer}}; do sleep 10; done"
-                         ExecStop=/usr/bin/bash -c "/usr/local/bin/{{.Values.specialResourceModule.metadata.name}} unload {{.Values.registry}}/{{.Values.specialResourceModule.metadata.name}}-{{.Values.groupName.driverContainer}}"
+                         ExecStart=/usr/bin/bash -c "while ! /usr/local/bin/{{.Values.specialResourceModule.metadata.name}} load {{.Values.registry}}/{{.Values.specialResourceModule.metadata.name}}-{{.Values.groupName.driverContainer}} {{.Values.kernelFullVersion}}; do sleep 10; done"
+                         ExecStop=/usr/bin/bash -c "/usr/local/bin/{{.Values.specialResourceModule.metadata.name}} unload {{.Values.registry}}/{{.Values.specialResourceModule.metadata.name}}-{{.Values.groupName.driverContainer}} {{.Values.kernelFullVersion}}"
                          StandardOutput=journal+console
  
                          [Install]

--- a/charts/example/acm-ice-0.0.1/templates/0003-placement.yaml
+++ b/charts/example/acm-ice-0.0.1/templates/0003-placement.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
- name: {{.Values.specialResourceModule.metadata.name}}-placement
+ name: {{ printf "%s-%s" .Values.specialResourceModule.metadata.name .Values.openShiftVersion | replace "." "-" | replace "_" "-" | trunc 63 }}
 spec:
   clusterConditions:
   - status: "True"
@@ -12,16 +12,20 @@ spec:
       operator: NotIn
       values:
       - local-cluster
+    - key: openshiftVersion
+      operator: In
+      values:
+      - {{ .Values.openShiftVersion }}
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
- name: {{.Values.specialResourceModule.metadata.name}}-binding
+ name: {{ printf "%s-%s" .Values.specialResourceModule.metadata.name .Values.openShiftVersion | replace "." "-" | replace "_" "-" | trunc 63 }}
 placementRef:
  apiGroup: apps.open-cluster-management.io
  kind: PlacementRule
- name: {{.Values.specialResourceModule.metadata.name}}-placement
+ name: {{ printf "%s-%s" .Values.specialResourceModule.metadata.name .Values.openShiftVersion | replace "." "-" | replace "_" "-" | trunc 63 }}
 subjects:
 - apiGroup: policy.open-cluster-management.io
   kind: Policy
-  name: policy-{{.Values.specialResourceModule.metadata.name}}-mc
+  name: {{ printf "%s-%s" .Values.specialResourceModule.metadata.name .Values.openShiftVersion | replace "." "-" | replace "_" "-" | trunc 63 }}

--- a/controllers/specialresourcemodule_controller.go
+++ b/controllers/specialresourcemodule_controller.go
@@ -80,6 +80,7 @@ type metadata struct {
 	KernelFullVersion     string                           `json:"kernelFullVersion"`
 	RTKernelFullVersion   string                           `json:"rtKernelFullVersion"`
 	DriverToolkitImage    string                           `json:"driverToolkitImage"`
+	OpenShiftVersion      string                           `json:"openShiftVersion"`
 	OSImageURL            string                           `json:"osImageURL"`
 	GroupName             sroruntime.ResourceGroupName     `json:"groupName"`
 	SpecialResourceModule srov1beta1.SpecialResourceModule `json:"specialResourceModule"`
@@ -91,6 +92,7 @@ type ocpVersionInfo struct {
 	DTKImage        string
 	OSVersion       string
 	OSImage         string
+	OCPVersion      string
 }
 
 // SpecialResourceModuleReconciler reconciles a SpecialResourceModule object
@@ -122,6 +124,7 @@ func getMetadata(srm srov1beta1.SpecialResourceModule, info ocpVersionInfo) meta
 		KernelFullVersion:   info.KernelVersion,
 		RTKernelFullVersion: info.RTKernelVersion,
 		DriverToolkitImage:  info.DTKImage,
+		OpenShiftVersion:    info.OCPVersion,
 		OSImageURL:          info.OSImage,
 		GroupName: sroruntime.ResourceGroupName{
 			DriverBuild:            "driver-build",
@@ -297,6 +300,10 @@ func (r *SpecialResourceModuleReconciler) getVersionInfoFromImage(ctx context.Co
 	if err != nil {
 		return ocpVersionInfo{}, fmt.Errorf("failed to get manifest's last layer for image '%s': %w", entry, err)
 	}
+	ocpVersion, err := r.Registry.ReleaseMetadataOCPVersion(manifestsLastLayer)
+	if err != nil {
+		return ocpVersionInfo{}, fmt.Errorf("failed to get OCP version from image '%s': %w", entry, err)
+	}
 	dtkURL, err := r.Registry.ReleaseManifests(manifestsLastLayer)
 	if err != nil {
 		return ocpVersionInfo{}, fmt.Errorf("failed to get DTK URL from image '%s': %w", entry, err)
@@ -328,6 +335,7 @@ func (r *SpecialResourceModuleReconciler) getVersionInfoFromImage(ctx context.Co
 		DTKImage:        dtkURL,
 		OSVersion:       dtkEntry.OSVersion,
 		OSImage:         entry,
+		OCPVersion:      ocpVersion,
 	}, nil
 }
 

--- a/pkg/registry/mock_registry_api.go
+++ b/pkg/registry/mock_registry_api.go
@@ -127,3 +127,18 @@ func (mr *MockRegistryMockRecorder) ReleaseManifests(arg0 interface{}) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseManifests", reflect.TypeOf((*MockRegistry)(nil).ReleaseManifests), arg0)
 }
+
+// ReleaseMetadataOCPVersion mocks base method.
+func (m *MockRegistry) ReleaseMetadataOCPVersion(arg0 v1.Layer) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReleaseMetadataOCPVersion", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReleaseMetadataOCPVersion indicates an expected call of ReleaseMetadataOCPVersion.
+func (mr *MockRegistryMockRecorder) ReleaseMetadataOCPVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseMetadataOCPVersion", reflect.TypeOf((*MockRegistry)(nil).ReleaseMetadataOCPVersion), arg0)
+}


### PR DESCRIPTION
Add functionality to extract OCP version from images and use it as
a helm variable.
Tweak ICE driver example to fix bug 2093357