### PR TITLE
Bug 2093277: Add ACM resources to resourceVersion update list

### DIFF
--- a/internal/resourcehelper/helper.go
+++ b/internal/resourcehelper/helper.go
@@ -43,6 +43,9 @@ var (
 		"ValidatingWebhookConfiguration": true,
 		"Deployment":                     true,
 		"ImagePolicy":                    true,
+		"PlacementBinding":               true,
+		"PlacementRule":                  true,
+		"Policy":                         true,
 	}
 )
 


### PR DESCRIPTION
In order to update objects these need to get the resourceVersion from
the existing ones. There is a list to determine which resources should
be able to grab this field and ACM resources were not part of it.